### PR TITLE
feat(telegram): refresh MCP servers on new sessions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
   "mypy>=1.8.0",
   "types-PyYAML>=6.0.0",
   "anthropic>=0.40.0",
+  "croniter>=1.3.0",
 ]
 
 [project.scripts]

--- a/src/amcp/progressive/tool_view.py
+++ b/src/amcp/progressive/tool_view.py
@@ -55,8 +55,10 @@ class ProgressiveToolView:
         relevant_tools = self._find_explicit_tool_mentions(user_input, set(tool_map.keys()))
 
         always: list[dict[str, Any]] = []
+        always_names: set[str] = set()
         candidates: list[tuple[dict[str, Any], float]] = []
         excluded: list[str] = []
+        score_by_name: dict[str, float] = {}
 
         for spec in tools:
             name = self._tool_name(spec)
@@ -70,6 +72,7 @@ class ProgressiveToolView:
 
             if tier == ToolTier.ALWAYS:
                 always.append(spec)
+                always_names.add(name)
                 continue
 
             score = self.scorer.score_tool(
@@ -87,6 +90,7 @@ class ProgressiveToolView:
                 score = min(score + 0.10, 1.0)
 
             candidates.append((spec, score))
+            score_by_name[name] = score
 
         selected = list(always)
         remaining_budget = max(budget_tokens - self._estimate_specs_tokens(always), 0)
@@ -104,12 +108,50 @@ class ProgressiveToolView:
             else:
                 excluded.append(self._tool_name(spec))
 
+        self._ensure_mcp_visibility(
+            selected=selected,
+            candidates=candidates,
+            always_names=always_names,
+            score_by_name=score_by_name,
+        )
+
         hidden_count = max(len(tools) - len(selected), 0)
         return ToolSelectionResult(
             selected_tools=selected,
             hidden_count=hidden_count,
             excluded_tools=sorted({name for name in excluded if name}),
         )
+
+    def _ensure_mcp_visibility(
+        self,
+        *,
+        selected: list[dict[str, Any]],
+        candidates: list[tuple[dict[str, Any], float]],
+        always_names: set[str],
+        score_by_name: dict[str, float],
+    ) -> None:
+        has_selected_mcp = any(self._tool_name(spec).startswith("mcp.") for spec in selected)
+        if has_selected_mcp:
+            return
+
+        mcp_candidates = [item for item in candidates if self._tool_name(item[0]).startswith("mcp.")]
+        if not mcp_candidates:
+            return
+
+        mcp_candidates.sort(key=lambda item: item[1], reverse=True)
+        mcp_spec = mcp_candidates[0][0]
+
+        removable = [
+            spec
+            for spec in selected
+            if self._tool_name(spec) not in always_names and not self._tool_name(spec).startswith("mcp.")
+        ]
+        if removable:
+            removable.sort(key=lambda spec: score_by_name.get(self._tool_name(spec), 0.0))
+            selected.remove(removable[0])
+
+        if all(self._tool_name(spec) != self._tool_name(mcp_spec) for spec in selected):
+            selected.append(mcp_spec)
 
     def _resolve_tier(self, tool_name: str, overrides: dict[str, str]) -> ToolTier:
         raw_override = overrides.get(tool_name) or (overrides.get("mcp.*") if tool_name.startswith("mcp.") else None)

--- a/src/amcp/telegram/bot.py
+++ b/src/amcp/telegram/bot.py
@@ -13,8 +13,9 @@ from typing import TYPE_CHECKING, Any
 
 from ..agent import Agent, BusyError, create_agent_by_name
 from ..agent_spec import get_default_agent_spec
-from ..config import load_config, save_config
+from ..config import CONFIG_FILE, load_config, save_config
 from ..event_bus import EventType, get_event_bus
+from ..mcp_client import list_mcp_tools
 from ..memory import get_memory_manager
 from ..multi_agent import get_agent_registry
 from .auth import AuthMiddleware
@@ -124,6 +125,54 @@ class TelegramBot:
         allowed = ", ".join(str(u) for u in sorted(self._auth.allowed_users)) or "none"
         admins = ", ".join(str(u) for u in sorted(self._auth.admin_users)) or "none"
         return f"allowed_users: {allowed}\nadmin_users: {admins}"
+
+    async def refresh_mcp_servers(self) -> str:
+        """Reload MCP configuration and probe server availability."""
+        cfg = load_config()
+        chat_cfg = cfg.chat
+
+        if chat_cfg and chat_cfg.mcp_tools_enabled is False:
+            return "MCP reload skipped: mcp_tools_enabled=false."
+
+        missing: list[str] = []
+        if chat_cfg and chat_cfg.mcp_servers:
+            selected = [name for name in chat_cfg.mcp_servers if name in cfg.servers]
+            missing = [name for name in chat_cfg.mcp_servers if name not in cfg.servers]
+        else:
+            selected = list(cfg.servers.keys())
+
+        if not selected:
+            if missing:
+                return f"MCP reload: no valid servers (missing config: {', '.join(missing)})."
+            return (
+                f"MCP reload: no configured servers in {CONFIG_FILE}. "
+                "Check whether Telegram process is using the expected config path."
+            )
+
+        async def _probe(server_name: str) -> tuple[str, int, str | None]:
+            try:
+                tools = await list_mcp_tools(cfg.servers[server_name])
+                return server_name, len(tools), None
+            except Exception as exc:
+                error = str(exc).replace("\n", " ").strip()
+                return server_name, 0, error
+
+        results = await asyncio.gather(*(_probe(name) for name in selected))
+
+        ready = [result for result in results if result[2] is None]
+        failed = [result for result in results if result[2] is not None]
+        total_tools = sum(tool_count for _, tool_count, _ in ready)
+
+        summary = f"MCP reloaded: {len(ready)}/{len(selected)} servers ready, {total_tools} tools discovered."
+        details: list[str] = []
+        if missing:
+            details.append(f"missing config: {', '.join(missing)}")
+        if failed:
+            failures = ", ".join(f"{name} ({(err or 'unknown error')[:120]})" for name, _, err in failed)
+            details.append(f"failed: {failures}")
+        if details:
+            summary += "\n" + "\n".join(details)
+        return summary
 
     def add_allowed_user(self, user_id: int) -> None:
         self._auth.allowed_users.add(user_id)

--- a/src/amcp/telegram/handlers.py
+++ b/src/amcp/telegram/handlers.py
@@ -571,7 +571,15 @@ class TelegramHandlers:
             return
         if args[0] == "new":
             session = self._session_manager.create_session(chat_id)
-            await self._bot.send_text(chat_id, f"Created session: {session.session_id}")
+            message = f"Created session: {session.session_id}"
+            refresh_mcp = getattr(self._bot, "refresh_mcp_servers", None)
+            if callable(refresh_mcp):
+                try:
+                    mcp_summary = await refresh_mcp()
+                    message += f"\n{mcp_summary}"
+                except Exception as exc:
+                    message += f"\nMCP reload failed: {exc}"
+            await self._bot.send_text(chat_id, message)
             return
         if args[0] == "switch" and len(args) > 1:
             if self._session_manager.switch_session(chat_id, args[1]):

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -87,13 +87,10 @@ class TestAMCPAgent:
     @pytest.mark.asyncio
     async def test_initialize_with_client_capabilities(self):
         """Test initialize stores client capabilities."""
-        from acp.schema import ClientCapabilities, FileSystemCapability
+        from acp.schema import ClientCapabilities
 
         agent = AMCPAgent()
-        client_caps = ClientCapabilities(
-            fs=FileSystemCapability(read_text_file=True, write_text_file=True),
-            terminal=True,
-        )
+        client_caps = ClientCapabilities(terminal=True)
         await agent.initialize(protocol_version=1, client_capabilities=client_caps)
         assert agent._client_capabilities == client_caps
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -46,7 +46,8 @@ class TestCreateLLMClient:
         except ImportError:
             pytest.skip("anthropic package not installed")
 
-    def test_none_config_uses_defaults(self):
+    def test_none_config_uses_defaults(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         client = create_llm_client(None)
         assert isinstance(client, OpenAIClient)
 

--- a/tests/test_progressive.py
+++ b/tests/test_progressive.py
@@ -66,6 +66,33 @@ def test_progressive_tool_view_keeps_always_tools_and_respects_budget():
     assert len(result.selected_tools) <= len(tools)
 
 
+def test_progressive_tool_view_keeps_at_least_one_mcp_tool_visible():
+    scorer = RelevanceScorer()
+    view = ProgressiveToolView(scorer)
+    tools = [
+        _tool_spec("read_file", "Read files from workspace"),
+        _tool_spec("grep", "Search text patterns"),
+        _tool_spec("think", "Internal planning"),
+        _tool_spec("apply_patch", "Edit files with patch diffs"),
+        _tool_spec("mcp.tavily.tavily_search", "Search the web for current information"),
+        _tool_spec("mcp.tavily.tavily_extract", "Extract web page content from URLs"),
+    ]
+
+    result = view.select_tools(
+        tools=tools,
+        user_input="帮我看看这个问题",
+        conversation=[],
+        usage=ToolUsageTracker.from_history([]),
+        budget_tokens=120,
+        relevance_threshold=0.95,
+        tier_overrides={},
+    )
+
+    names = {t["function"]["name"] for t in result.selected_tools}
+    assert {"read_file", "grep", "think"}.issubset(names)
+    assert any(name.startswith("mcp.") for name in names)
+
+
 def test_progressive_skill_view_falls_back_when_budget_is_small():
     scorer = RelevanceScorer()
     view = ProgressiveSkillView(scorer)

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -68,6 +68,44 @@ def test_session_manager_creates_sessions():
     assert manager.get_current_session_id(123) == session2.session_id
 
 
+def test_handle_session_new_refreshes_mcp():
+    async def _run():
+        class _SessionBot(_FakeBot):
+            def __init__(self, config: TelegramConfig) -> None:
+                super().__init__(config)
+                self.sent: list[tuple[int, str]] = []
+
+            async def send_text(self, chat_id: int, text: str) -> None:
+                self.sent.append((chat_id, text))
+
+            async def refresh_mcp_servers(self) -> str:
+                return "MCP reloaded: ok"
+
+        fake_bot = _SessionBot(TelegramConfig())
+        manager = SessionManager(agent_factory=_FakeAgent, session_timeout=60)
+        handlers = TelegramHandlers(
+            bot=fake_bot,
+            session_manager=manager,
+            auth=AuthMiddleware(allowed_users={42}, admin_users=set()),
+            rate_limiter=RateLimiter(limit=100),
+        )
+        update = SimpleNamespace(
+            effective_chat=SimpleNamespace(id=123, type="private"),
+            effective_user=SimpleNamespace(id=42),
+            message=None,
+        )
+        context = SimpleNamespace(args=["new"])
+
+        await handlers.handle_session(update, context)
+
+        assert fake_bot.sent
+        _, text = fake_bot.sent[0]
+        assert "Created session:" in text
+        assert "MCP reloaded: ok" in text
+
+    asyncio.run(_run())
+
+
 # --- Metadata injection tests ---
 
 
@@ -291,6 +329,61 @@ def _make_bot_for_typing(*, typing_indicator: bool = True, typing_interval: int 
             config=config,
         )
     return bot
+
+
+def test_refresh_mcp_servers_reports_results():
+    async def _run():
+        bot = _make_bot_for_typing()
+        server_a = object()
+        server_b = object()
+        cfg = SimpleNamespace(
+            chat=SimpleNamespace(mcp_tools_enabled=True, mcp_servers=["a", "b", "missing"]),
+            servers={"a": server_a, "b": server_b},
+        )
+
+        async def _fake_list_tools(server):
+            if server is server_a:
+                return [{"name": "tool_a"}, {"name": "tool_b"}]
+            raise RuntimeError("offline")
+
+        with (
+            patch("amcp.telegram.bot.load_config", return_value=cfg),
+            patch("amcp.telegram.bot.list_mcp_tools", new=_fake_list_tools),
+        ):
+            summary = await bot.refresh_mcp_servers()
+
+        assert "MCP reloaded: 1/2 servers ready, 2 tools discovered." in summary
+        assert "missing config: missing" in summary
+        assert "failed: b (offline)" in summary
+
+    asyncio.run(_run())
+
+
+def test_refresh_mcp_servers_skips_when_disabled():
+    async def _run():
+        bot = _make_bot_for_typing()
+        cfg = SimpleNamespace(chat=SimpleNamespace(mcp_tools_enabled=False), servers={})
+
+        with patch("amcp.telegram.bot.load_config", return_value=cfg):
+            summary = await bot.refresh_mcp_servers()
+
+        assert summary == "MCP reload skipped: mcp_tools_enabled=false."
+
+    asyncio.run(_run())
+
+
+def test_refresh_mcp_servers_reports_config_path_when_empty():
+    async def _run():
+        bot = _make_bot_for_typing()
+        cfg = SimpleNamespace(chat=SimpleNamespace(mcp_tools_enabled=True, mcp_servers=None), servers={})
+
+        with patch("amcp.telegram.bot.load_config", return_value=cfg):
+            summary = await bot.refresh_mcp_servers()
+
+        assert "MCP reload: no configured servers in" in summary
+        assert "config.toml" in summary
+
+    asyncio.run(_run())
 
 
 def test_typing_start_creates_task():


### PR DESCRIPTION


# Pull Request

## Description
<!-- Describe your changes in detail -->
Reload MCP servers when creating a new Telegram session and report readiness/tool discovery details to users. Also ensure progressive tool selection keeps at least one MCP tool visible when MCP tools are available, and add coverage for both behaviors.
## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing
<!-- Describe the tests you ran to verify your changes -->

```bash
# Example test commands
make test
make lint
```

## Related Issues
<!-- Link to related issues -->
Closes #
