### PR TITLE
fix: raise bash tool limit for long tasks

### DIFF
--- a/src/amcp/agent.py
+++ b/src/amcp/agent.py
@@ -43,6 +43,8 @@ from .ui import LiveUI
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_BASH_TOOL_LIMIT = 100
+
 
 class AgentExecutionError(Exception):
     """Raised when agent execution fails."""
@@ -455,16 +457,25 @@ class Agent:
             return False
 
         # bash can dump large files and quickly balloon tool context during
-        # repo analysis. Keep the per-request loop bounded; session totals are
-        # still tracked in tool_calls_history for diagnostics.
+        # repo analysis. Keep a configurable per-request loop bound; session
+        # totals are still tracked in tool_calls_history for diagnostics.
         if tool_name == "bash":
-            if current_conversation_calls >= 12:
-                self.console.print("[yellow]Per-request bash limit reached (12 calls)[/yellow]")
+            limit = self._resolve_bash_tool_limit()
+            if limit > 0 and current_conversation_calls >= limit:
+                self.console.print(f"[yellow]Per-request bash limit reached ({limit} calls)[/yellow]")
                 return True
             return False
 
         # MCP tools: 100 per tool per conversation
         return tool_name.startswith("mcp.") and current_conversation_calls >= 100
+
+    def _resolve_bash_tool_limit(self) -> int:
+        """Resolve the per-request bash limit; values <= 0 disable this limit."""
+        cfg = load_config()
+        configured = cfg.chat.bash_tool_limit if cfg.chat else None
+        if isinstance(configured, int) and not isinstance(configured, bool):
+            return configured
+        return DEFAULT_BASH_TOOL_LIMIT
 
     def _reset_current_conversation_tool_calls(self) -> None:
         """Reset the current conversation tool calls counter for a new conversation."""

--- a/src/amcp/config.py
+++ b/src/amcp/config.py
@@ -70,6 +70,7 @@ class ChatConfig:
 
     # Tool calling settings
     tool_loop_limit: int | None = None
+    bash_tool_limit: int | None = None
     default_max_lines: int | None = None
     read_roots: list[str] | None = None  # list of allowed root paths for read_file
     # MCP tool exposure
@@ -178,6 +179,7 @@ _DEFAULT = {
         "model": "zai-org/GLM-4.6",
         # "api_key": ""  # optional; users can add this if they want config-based auth
         "tool_loop_limit": 300,
+        "bash_tool_limit": 100,
         "default_max_lines": 400,
         # "read_roots": ["."]  # optional; defaults to current working directory when unset
         "mcp_tools_enabled": True,
@@ -287,6 +289,7 @@ def _decode_chat(raw: Mapping[str, object] | None) -> ChatConfig | None:
     api_key = raw.get("api_key")
     api_type = raw.get("api_type")
     tool_loop_limit = raw.get("tool_loop_limit")
+    bash_tool_limit = raw.get("bash_tool_limit")
     default_max_lines = raw.get("default_max_lines")
     read_roots = raw.get("read_roots")
     mcp_tools_enabled = raw.get("mcp_tools_enabled")
@@ -309,6 +312,7 @@ def _decode_chat(raw: Mapping[str, object] | None) -> ChatConfig | None:
         api_type=str(api_type) if api_type is not None else None,
         model_config=model_config,
         tool_loop_limit=int(str(tool_loop_limit)) if tool_loop_limit is not None else None,
+        bash_tool_limit=int(str(bash_tool_limit)) if bash_tool_limit is not None else None,
         default_max_lines=int(str(default_max_lines)) if default_max_lines is not None else None,
         read_roots=[str(p) for p in read_roots] if isinstance(read_roots, list) else None,
         mcp_tools_enabled=bool(mcp_tools_enabled) if mcp_tools_enabled is not None else None,
@@ -524,6 +528,8 @@ def _encode_chat(c: ChatConfig | None) -> dict | None:
         out["model_config"] = model_config_dict
     if c.tool_loop_limit is not None:
         out["tool_loop_limit"] = int(c.tool_loop_limit)
+    if c.bash_tool_limit is not None:
+        out["bash_tool_limit"] = int(c.bash_tool_limit)
     if c.default_max_lines is not None:
         out["default_max_lines"] = int(c.default_max_lines)
     if c.read_roots is not None:

--- a/src/amcp/init_wizard.py
+++ b/src/amcp/init_wizard.py
@@ -561,6 +561,7 @@ def run_init_wizard() -> Path:
         api_key=api_key if api_key else None,
         model_config=model_config,
         tool_loop_limit=300,
+        bash_tool_limit=100,
         default_max_lines=400,
         mcp_tools_enabled=True,
         write_tool_enabled=True,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -10,7 +10,7 @@ import pytest
 
 from amcp.agent import Agent, AgentExecutionError, BusyError, MaxStepsReached
 from amcp.agent_spec import ResolvedAgentSpec
-from amcp.config import AMCPConfig, ContextConfig
+from amcp.config import AMCPConfig, ChatConfig, ContextConfig
 from amcp.hooks import HookOutput
 from amcp.memory import MemoryManager, MemoryStore
 from amcp.multi_agent import AgentMode
@@ -124,9 +124,33 @@ class TestAgentToolLimits:
             mock_load.return_value = MagicMock()
             agent = Agent(session_id="test-session")
 
-        agent.current_conversation_tool_calls = [{"tool": "bash"} for _ in range(12)]
+            agent.current_conversation_tool_calls = [{"tool": "bash"} for _ in range(100)]
 
-        assert agent._should_limit_tool_calls("bash") is True
+            assert agent._should_limit_tool_calls("bash") is True
+
+    def test_bash_per_request_limit_is_configurable(self, tmp_path):
+        """Config can tune the bash cap for long-running Telegram agents."""
+        with patch("amcp.agent.Path.home") as mock_home, patch("amcp.agent.load_config") as mock_load:
+            mock_home.return_value = tmp_path
+            mock_load.return_value = AMCPConfig(servers={}, chat=ChatConfig(bash_tool_limit=20))
+            agent = Agent(session_id="test-session")
+
+            agent.current_conversation_tool_calls = [{"tool": "bash"} for _ in range(19)]
+            assert agent._should_limit_tool_calls("bash") is False
+
+            agent.current_conversation_tool_calls = [{"tool": "bash"} for _ in range(20)]
+            assert agent._should_limit_tool_calls("bash") is True
+
+    def test_bash_per_request_limit_can_be_disabled(self, tmp_path):
+        """Non-positive bash_tool_limit disables only the bash-specific cap."""
+        with patch("amcp.agent.Path.home") as mock_home, patch("amcp.agent.load_config") as mock_load:
+            mock_home.return_value = tmp_path
+            mock_load.return_value = AMCPConfig(servers={}, chat=ChatConfig(bash_tool_limit=0))
+            agent = Agent(session_id="test-session")
+
+            agent.current_conversation_tool_calls = [{"tool": "bash"} for _ in range(500)]
+
+            assert agent._should_limit_tool_calls("bash") is False
 
     def test_bash_limit_resets_for_new_request(self, tmp_path):
         """A new user request can use bash again after per-request reset."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,24 @@ def test_decode_encode_context_roundtrip():
     assert encoded["tool_tiers"]["task"] == "hidden"
 
 
+def test_decode_encode_chat_tool_limits_roundtrip():
+    raw = {
+        "tool_loop_limit": 300,
+        "bash_tool_limit": 100,
+        "default_max_lines": 400,
+    }
+
+    cfg = config_module._decode_chat(raw)
+    assert cfg is not None
+    assert cfg.tool_loop_limit == 300
+    assert cfg.bash_tool_limit == 100
+
+    encoded = config_module._encode_chat(cfg)
+    assert encoded is not None
+    assert encoded["tool_loop_limit"] == 300
+    assert encoded["bash_tool_limit"] == 100
+
+
 def test_decode_encode_automation_roundtrip():
     raw = {
         "enabled": True,


### PR DESCRIPTION
# Pull Request

## Description
Raise the per-request bash tool cap from the previous hard-coded 12 calls to a safer default of 100 calls, and make the cap configurable via `chat.bash_tool_limit`.

This keeps a guardrail against runaway tool loops while allowing long-running Telegram/sandbox coding tasks to complete without prematurely forcing a final answer. Setting `bash_tool_limit = 0` disables the bash-specific cap.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing

```bash
.venv/bin/python -m pytest tests/test_agent.py::TestAgentToolLimits tests/test_config.py -q
.venv/bin/python -m ruff format src/amcp/agent.py src/amcp/config.py src/amcp/init_wizard.py tests/test_agent.py tests/test_config.py --check
.venv/bin/python -m ruff check src/amcp/agent.py src/amcp/config.py src/amcp/init_wizard.py tests/test_agent.py tests/test_config.py
```

## Related Issues
N/A
