### PR TITLE
fix: set AMCP user agent for OpenAI clients

### DIFF
--- a/src/amcp/chat.py
+++ b/src/amcp/chat.py
@@ -16,6 +16,7 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 
 from .config import AMCPConfig, ChatConfig, load_config
+from .llm import AMCP_USER_AGENT
 from .mcp_client import call_mcp_tool, list_mcp_tools
 from .readfile import read_file_with_ranges
 
@@ -60,7 +61,11 @@ def _make_client(base_url: str, api_key: str | None):
     except ImportError:  # pragma: no cover
         console.print("[red]openai package not installed. Please install dependencies.[/red]")
         raise
-    return OpenAI(base_url=base_url, api_key=api_key or "")
+    return OpenAI(
+        base_url=base_url,
+        api_key=api_key or "",
+        default_headers={"User-Agent": AMCP_USER_AGENT},
+    )
 
 
 def _stream_chat(client, model: str, messages: list[dict], stream: bool = True) -> str:

--- a/src/amcp/llm.py
+++ b/src/amcp/llm.py
@@ -15,6 +15,8 @@ from .config import ChatConfig
 ToolCall = dict[str, Any]
 Message = dict[str, Any]
 
+AMCP_USER_AGENT = "AMCPAgent"
+
 
 def _extract_think_tags(content: str) -> tuple[str | None, str]:
     """Extract content from <think> tags and return (thinking, remaining_content)."""
@@ -60,7 +62,11 @@ class OpenAIClient(BaseLLMClient):
     def __init__(self, base_url: str, api_key: str | None, model: str):
         from openai import OpenAI
 
-        self.client = OpenAI(base_url=base_url, api_key=api_key or "")
+        self.client = OpenAI(
+            base_url=base_url,
+            api_key=api_key or "",
+            default_headers={"User-Agent": AMCP_USER_AGENT},
+        )
         self.model = model
 
     def chat(
@@ -178,7 +184,11 @@ class OpenAIResponsesClient(BaseLLMClient):
     def __init__(self, base_url: str, api_key: str | None, model: str):
         from openai import OpenAI
 
-        self.client = OpenAI(base_url=base_url, api_key=api_key or "")
+        self.client = OpenAI(
+            base_url=base_url,
+            api_key=api_key or "",
+            default_headers={"User-Agent": AMCP_USER_AGENT},
+        )
         self.model = model
 
     def chat(


### PR DESCRIPTION
# Pull Request

## Description
Sets a custom `User-Agent: AMCPAgent` on AMCP-created OpenAI SDK clients. This avoids providers or WAFs blocking the OpenAI Python SDK default user agent while preserving existing OpenAI-compatible request behavior.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing

```bash
.venv/bin/ruff format src/amcp/llm.py src/amcp/chat.py
.venv/bin/ruff check src/amcp/llm.py src/amcp/chat.py
PYTHONPATH=src .venv/bin/python - <<'PY'
from amcp.llm import AMCP_USER_AGENT, OpenAIClient
print(AMCP_USER_AGENT)
client = OpenAIClient('https://example.com/v1', 'dummy', 'dummy')
print(client.client.default_headers.get('User-Agent'))
PY
```

Also verified in the running E2B sandbox that OpenAI SDK requests using `default_headers={"User-Agent": "AMCPAgent"}` successfully reach the configured OpenAI-compatible provider.

## Related Issues

Closes #
