### PR TITLE
feat: add telegram sender photo support

### DIFF
--- a/src/amcp/builtin_skills/telegram-sender/SKILL.md
+++ b/src/amcp/builtin_skills/telegram-sender/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telegram-sender
-description: Send and edit Telegram messages via Bot API. Use when AMCP needs to send a message, reply to a specific message, edit an existing message, or push proactive notifications (cron results, heartbeat alerts, task status). Requires AMCP_TELEGRAM_BOT_TOKEN env var.
+description: Send and edit Telegram messages, and send photos via Bot API. Use when AMCP needs to send text, reply to a specific message, edit an existing message, send an image, or push proactive notifications (cron results, heartbeat alerts, task status). Requires AMCP_TELEGRAM_BOT_TOKEN env var.
 ---
 
 # Telegram Sender
@@ -13,6 +13,8 @@ Assumption: `AMCP_TELEGRAM_BOT_TOKEN` is already set in the environment.
 
 - `chat_id` (required) — from inbound message metadata or config
 - message content (required for send/edit)
+- photo source (required for photo): local file path, HTTP(S) image URL, or Telegram `file_id`
+- photo caption (optional, max 1024 characters after Telegram entity parsing)
 - `reply_to_message_id` (optional, for threaded reply)
 - `message_id` (required for edit)
 
@@ -21,8 +23,10 @@ Assumption: `AMCP_TELEGRAM_BOT_TOKEN` is already set in the environment.
 1. If handling a Telegram message and `message_id` is known, prefer reply mode (`--reply-to`).
 2. If source metadata says sender is a bot (`sender_is_bot=true`), do not use reply mode; use `--source-is-bot --source-username <USERNAME>` instead.
 3. For long-running tasks: send an acknowledgment first, then edit it with the final result.
-4. Keep content concise and action-oriented.
-5. Use literal newlines in message text.
+4. Use `photo` when the response depends on an image artifact or generated picture.
+5. Prefer local file paths for newly generated images. Use a Telegram `file_id` only when reusing a previously uploaded file.
+6. Keep content concise and action-oriented.
+7. Use literal newlines in message text and captions.
 
 ## Active Response Policy
 
@@ -67,6 +71,19 @@ python ./scripts/telegram_send.py edit \
   --chat-id <CHAT_ID> \
   --message-id <MESSAGE_ID> \
   --text "<TEXT>"
+
+# Send photo from local path, URL, or Telegram file_id
+python ./scripts/telegram_send.py photo \
+  --chat-id <CHAT_ID> \
+  --photo "<PATH_OR_URL_OR_FILE_ID>" \
+  --caption "<OPTIONAL_CAPTION>"
+
+# Reply with a photo
+python ./scripts/telegram_send.py photo \
+  --chat-id <CHAT_ID> \
+  --photo "<PATH_OR_URL_OR_FILE_ID>" \
+  --caption "<OPTIONAL_CAPTION>" \
+  --reply-to <MESSAGE_ID>
 ```
 
 For actions not covered by this script, use `curl` to call Telegram Bot API directly:
@@ -90,9 +107,29 @@ For actions not covered by this script, use `curl` to call Telegram Bot API dire
 - `--text`, `-x`: required
 - `--token`, `-t`: optional (normally not needed)
 
+### `telegram_send.py photo`
+
+- `--chat-id`, `-c`: required
+- `--photo`, `-p`: required; local file path, HTTP(S) URL, or Telegram `file_id`
+- `--caption`, `-m`: optional caption; Markdown supported and converted to MarkdownV2
+- `--reply-to`, `-r`: optional message ID
+- `--token`, `-t`: optional (normally not needed)
+- `--source-is-bot`: optional flag
+- `--source-username`: required when `--source-is-bot` is set
+
+Photo behavior:
+
+- Local paths are uploaded with multipart/form-data.
+- HTTP(S) URLs are downloaded to a temporary file and then uploaded, which avoids CDN
+  content-type issues that can make direct Telegram URL sends fail.
+- Telegram `file_id` values are sent directly to reuse an existing upload.
+- Captions follow Telegram's `sendPhoto` limit: 0-1024 characters after entity parsing.
+
 ## Failure Handling
 
 - On HTTP errors, inspect API response text and adjust identifiers/permissions.
 - If edit fails (message not editable), fall back to a new send.
 - If reply target is invalid, resend without `--reply-to`.
+- If photo upload fails, verify the file exists, the URL is publicly fetchable from the
+  current environment, or the `file_id` belongs to this bot.
 - For task-level failures, notify the user with what failed, what completed, and next steps.

--- a/src/amcp/builtin_skills/telegram-sender/scripts/telegram_send.py
+++ b/src/amcp/builtin_skills/telegram-sender/scripts/telegram_send.py
@@ -10,13 +10,18 @@
 """
 Telegram Bot Message Sender for AMCP.
 
-Send or edit messages via Telegram Bot API.
+Send or edit messages and photos via Telegram Bot API.
 Uses telegramify_markdown for proper MarkdownV2 conversion.
 """
 
 import argparse
+import mimetypes
 import os
 import sys
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+from urllib.parse import urlparse
 
 import requests
 
@@ -27,12 +32,73 @@ except ImportError:
     sys.exit(1)
 
 
+PHOTO_CAPTION_LIMIT = 1024
+DOWNLOAD_CHUNK_SIZE = 64 * 1024
+IMAGE_SUFFIX_BY_CONTENT_TYPE = {
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+}
+
+
 def _unescape_newlines(text: str) -> str:
     """Convert escaped newline sequences to real newlines."""
     result = text.replace("\\n", "\n")
     result = result.replace("\\r\\n", "\r\n")
     result = result.replace("\\r", "\r")
     return result
+
+
+def _to_markdownv2(text: str) -> str:
+    """Convert user-friendly markdown text to Telegram MarkdownV2."""
+    return markdownify(_unescape_newlines(text)).rstrip("\n")
+
+
+def _is_url(value: str) -> bool:
+    """Return whether value is an HTTP(S) URL."""
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _looks_like_file_id(value: str) -> bool:
+    """Heuristically detect Telegram file_id values.
+
+    Telegram file IDs are opaque strings. Avoid classifying local paths or URLs as file IDs;
+    otherwise accept long slash-free values that commonly appear in Bot API responses.
+    """
+    return len(value) > 40 and "/" not in value and "\\" not in value and not _is_url(value)
+
+
+def _guess_image_suffix(url: str, content_type: str | None) -> str:
+    """Choose a useful file suffix for a downloaded image."""
+    path_suffix = Path(urlparse(url).path).suffix.lower()
+    if path_suffix in {".jpg", ".jpeg", ".png", ".gif", ".webp"}:
+        return ".jpg" if path_suffix == ".jpeg" else path_suffix
+
+    media_type = (content_type or "").split(";", maxsplit=1)[0].strip().lower()
+    if media_type in IMAGE_SUFFIX_BY_CONTENT_TYPE:
+        return IMAGE_SUFFIX_BY_CONTENT_TYPE[media_type]
+
+    guessed = mimetypes.guess_extension(media_type) if media_type else None
+    if guessed in {".jpg", ".jpeg", ".png", ".gif", ".webp"}:
+        return ".jpg" if guessed == ".jpeg" else guessed
+
+    return ".jpg"
+
+
+def _download_to_temp(url: str) -> str:
+    """Download an image URL to a temporary file and return its path."""
+    response = requests.get(url, stream=True, timeout=60)
+    response.raise_for_status()
+
+    suffix = _guess_image_suffix(url, response.headers.get("content-type"))
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp_file:
+        for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+            if chunk:
+                tmp_file.write(chunk)
+        return tmp_file.name
 
 
 def send_message(
@@ -57,11 +123,10 @@ def send_message(
     """
     url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
 
-    text = _unescape_newlines(text)
     if mention_username:
         text = f"@{mention_username} {text}"
 
-    converted_text = markdownify(text).rstrip("\n")
+    converted_text = _to_markdownv2(text)
 
     payload = {
         "chat_id": chat_id,
@@ -76,6 +141,71 @@ def send_message(
     response.raise_for_status()
 
     return response.json()
+
+
+def send_photo(
+    bot_token: str,
+    chat_id: str,
+    photo: str,
+    caption: str | None = None,
+    reply_to_message_id: int | None = None,
+    mention_username: str | None = None,
+) -> dict:
+    """
+    Send a photo via Telegram Bot API.
+
+    Args:
+        bot_token: Telegram bot token
+        chat_id: Target chat ID
+        photo: Local file path, HTTP(S) URL, or Telegram file_id
+        caption: Optional photo caption (markdown supported, converted to MarkdownV2)
+        reply_to_message_id: Optional message ID to reply to
+        mention_username: Optional username to prefix with @ mention
+
+    Returns:
+        API response as dict
+    """
+    url = f"https://api.telegram.org/bot{bot_token}/sendPhoto"
+    payload = {"chat_id": chat_id}
+
+    if caption:
+        if mention_username:
+            caption = f"@{mention_username} {caption}"
+        converted_caption = _to_markdownv2(caption)
+        if len(converted_caption) > PHOTO_CAPTION_LIMIT:
+            raise ValueError(f"Photo caption is too long ({len(converted_caption)} > {PHOTO_CAPTION_LIMIT})")
+        payload["caption"] = converted_caption
+        payload["parse_mode"] = "MarkdownV2"
+
+    if reply_to_message_id:
+        payload["reply_to_message_id"] = reply_to_message_id
+
+    temp_path: str | None = None
+    upload_path: Path | None = None
+    try:
+        photo_path = Path(photo).expanduser()
+        if photo_path.is_file():
+            upload_path = photo_path
+        elif _is_url(photo):
+            temp_path = _download_to_temp(photo)
+            upload_path = Path(temp_path)
+        elif _looks_like_file_id(photo):
+            payload["photo"] = photo
+            response = requests.post(url, json=payload, timeout=30)
+            response.raise_for_status()
+            return response.json()
+        else:
+            raise ValueError("Photo must be a local file path, HTTP(S) URL, or Telegram file_id")
+
+        with upload_path.open("rb") as photo_file:
+            files = {"photo": (upload_path.name, photo_file)}
+            response = requests.post(url, data=payload, files=files, timeout=60)
+            response.raise_for_status()
+            return response.json()
+    finally:
+        if temp_path:
+            with suppress(OSError):
+                os.unlink(temp_path)
 
 
 def edit_message(bot_token: str, chat_id: str, message_id: int, text: str) -> dict:
@@ -93,8 +223,7 @@ def edit_message(bot_token: str, chat_id: str, message_id: int, text: str) -> di
     """
     url = f"https://api.telegram.org/bot{bot_token}/editMessageText"
 
-    text = _unescape_newlines(text)
-    converted_text = markdownify(text).rstrip("\n")
+    converted_text = _to_markdownv2(text)
 
     payload = {
         "chat_id": chat_id,
@@ -110,9 +239,7 @@ def edit_message(bot_token: str, chat_id: str, message_id: int, text: str) -> di
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Send or edit messages via Telegram Bot API (auto-converts to MarkdownV2)"
-    )
+    parser = argparse.ArgumentParser(description="Send or edit Telegram messages/photos (auto-converts to MarkdownV2)")
     sub = parser.add_subparsers(dest="action", required=True)
 
     # --- send ---
@@ -134,6 +261,25 @@ def main():
     edit_parser.add_argument("--message-id", "-i", type=int, required=True, help="ID of the message to edit")
     edit_parser.add_argument("--text", "-x", required=True, help="New message text (markdown supported)")
     edit_parser.add_argument("--token", "-t", help="Bot token (defaults to AMCP_TELEGRAM_BOT_TOKEN env)")
+
+    # --- photo ---
+    photo_parser = sub.add_parser("photo", help="Send a photo")
+    photo_parser.add_argument("--chat-id", "-c", required=True, help="Target chat ID")
+    photo_parser.add_argument(
+        "--photo",
+        "-p",
+        required=True,
+        help="Photo source: local file path, HTTP(S) URL, or Telegram file_id",
+    )
+    photo_parser.add_argument("--caption", "-m", help="Optional photo caption (markdown supported)")
+    photo_parser.add_argument("--token", "-t", help="Bot token (defaults to AMCP_TELEGRAM_BOT_TOKEN env)")
+    photo_parser.add_argument("--reply-to", "-r", type=int, help="Message ID to reply to")
+    photo_parser.add_argument(
+        "--source-is-bot",
+        action="store_true",
+        help="Source message sender is a bot; disables reply and uses @username style",
+    )
+    photo_parser.add_argument("--source-username", help="Username for @mention when --source-is-bot is set")
 
     args = parser.parse_args()
 
@@ -160,6 +306,27 @@ def main():
         elif args.action == "edit":
             edit_message(bot_token, args.chat_id, args.message_id, args.text)
             print(f"Message {args.message_id} edited successfully")
+
+        elif args.action == "photo":
+            reply_to = args.reply_to
+            mention_username = None
+            if args.source_is_bot:
+                if not args.source_username:
+                    print("Error: --source-username is required when --source-is-bot is set")
+                    sys.exit(1)
+                reply_to = None
+                mention_username = args.source_username
+
+            result = send_photo(
+                bot_token,
+                args.chat_id,
+                args.photo,
+                args.caption,
+                reply_to,
+                mention_username,
+            )
+            msg_id = result.get("result", {}).get("message_id", "?")
+            print(f"Photo sent (message_id={msg_id})")
 
     except requests.HTTPError as e:
         print(f"HTTP Error: {e}")

--- a/tests/test_telegram_sender_skill_script.py
+++ b/tests/test_telegram_sender_skill_script.py
@@ -1,0 +1,137 @@
+"""Tests for the built-in telegram-sender skill script."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "amcp"
+    / "builtin_skills"
+    / "telegram-sender"
+    / "scripts"
+    / "telegram_send.py"
+)
+
+
+@pytest.fixture
+def telegram_send_script(monkeypatch):
+    """Load telegram_send.py with lightweight optional dependency stubs."""
+    telegramify_markdown = types.SimpleNamespace(markdownify=lambda text: text)
+    requests_stub = types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "telegramify_markdown", telegramify_markdown)
+    monkeypatch.setitem(sys.modules, "requests", requests_stub)
+
+    spec = importlib.util.spec_from_file_location("telegram_send_skill_script", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse:
+    """Minimal response object for script request calls."""
+
+    def __init__(self, payload: dict | None = None, chunks: list[bytes] | None = None):
+        self._payload = payload or {"ok": True, "result": {"message_id": 123}}
+        self._chunks = chunks or []
+        self.headers = {"content-type": "image/png"}
+
+    def raise_for_status(self) -> None:
+        """Pretend the request succeeded."""
+
+    def json(self) -> dict:
+        """Return the fake Telegram payload."""
+        return self._payload
+
+    def iter_content(self, chunk_size: int):
+        """Yield fake download chunks."""
+        yield from self._chunks
+
+
+def test_send_photo_file_id_uses_json_payload(telegram_send_script):
+    """Telegram file_id sources should be sent directly without multipart upload."""
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeResponse()
+
+    telegram_send_script.requests = types.SimpleNamespace(post=fake_post)
+
+    result = telegram_send_script.send_photo(
+        "token",
+        "chat-1",
+        "AgACAgUAAxkBAAIB_LONG_FILE_ID_FOR_REUSE_WITH_BOT",
+        caption="hello",
+        reply_to_message_id=42,
+    )
+
+    assert result["ok"] is True
+    assert len(calls) == 1
+    url, kwargs = calls[0]
+    assert url == "https://api.telegram.org/bottoken/sendPhoto"
+    assert kwargs["json"] == {
+        "chat_id": "chat-1",
+        "caption": "hello",
+        "parse_mode": "MarkdownV2",
+        "reply_to_message_id": 42,
+        "photo": "AgACAgUAAxkBAAIB_LONG_FILE_ID_FOR_REUSE_WITH_BOT",
+    }
+    assert "files" not in kwargs
+
+
+def test_send_photo_local_path_uses_multipart_upload(telegram_send_script, tmp_path):
+    """Local photo paths should be uploaded as multipart/form-data."""
+    image_path = tmp_path / "image.png"
+    image_path.write_bytes(b"png data")
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeResponse()
+
+    telegram_send_script.requests = types.SimpleNamespace(post=fake_post)
+
+    telegram_send_script.send_photo("token", "chat-1", str(image_path), caption="caption")
+
+    assert len(calls) == 1
+    url, kwargs = calls[0]
+    assert url == "https://api.telegram.org/bottoken/sendPhoto"
+    assert kwargs["data"] == {
+        "chat_id": "chat-1",
+        "caption": "caption",
+        "parse_mode": "MarkdownV2",
+    }
+    assert kwargs["files"]["photo"][0] == "image.png"
+    assert "json" not in kwargs
+
+
+def test_send_photo_url_downloads_then_uploads_and_cleans_temp(telegram_send_script):
+    """HTTP(S) photos should be downloaded first, uploaded, then removed."""
+    uploaded_paths: list[Path] = []
+
+    def fake_get(url, **kwargs):
+        assert url == "https://cdn.example.com/photo"
+        assert kwargs == {"stream": True, "timeout": 60}
+        return FakeResponse(chunks=[b"chunk-1", b"chunk-2"])
+
+    def fake_post(url, **kwargs):
+        assert url == "https://api.telegram.org/bottoken/sendPhoto"
+        upload_file = kwargs["files"]["photo"][1]
+        uploaded_path = Path(upload_file.name)
+        uploaded_paths.append(uploaded_path)
+        assert uploaded_path.suffix == ".png"
+        assert uploaded_path.read_bytes() == b"chunk-1chunk-2"
+        return FakeResponse()
+
+    telegram_send_script.requests = types.SimpleNamespace(get=fake_get, post=fake_post)
+
+    telegram_send_script.send_photo("token", "chat-1", "https://cdn.example.com/photo")
+
+    assert len(uploaded_paths) == 1
+    assert not uploaded_paths[0].exists()


### PR DESCRIPTION
# Pull Request

## Description
Adds photo sending support to the built-in `telegram-sender` skill.

Highlights:
- Adds `telegram_send.py photo` backed by Telegram Bot API `sendPhoto`
- Supports local file uploads, HTTP(S) URL download-then-upload, and Telegram `file_id` reuse
- Shares MarkdownV2 conversion across send/edit/photo paths
- Documents photo usage, caption limits, and failure handling in the skill guide
- Adds unit coverage for file_id, local multipart upload, and URL temporary download cleanup

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Testing

```bash
./.venv/bin/ruff format src/amcp/builtin_skills/telegram-sender/scripts/telegram_send.py tests/test_telegram_sender_skill_script.py
./.venv/bin/ruff check src/amcp/builtin_skills/telegram-sender/scripts/telegram_send.py tests/test_telegram_sender_skill_script.py
./.venv/bin/python -m pytest -q tests/test_telegram_sender_skill_script.py
git diff --check
```

## Related Issues

None.
