### PR TITLE
Remove cron CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ uvx amcp-agent --once "summarize this repository and suggest the next test to ru
 | **Research** | Web search/fetch tools plus MCP server integration over stdio or HTTP/SSE |
 | **Agent orchestration** | Primary/subagent architecture with `coder`, `explorer`, `planner`, and `focused_coder` types |
 | **Context & memory** | Persistent sessions, AGENTS.md rules, smart compaction, progressive tool/skill loading, MEMORY.md/HISTORY.md |
-| **Interfaces** | CLI, ACP for IDEs, FastAPI HTTP/WebSocket server, Telegram bot, scheduled automation jobs |
+| **Interfaces** | CLI, ACP for IDEs, FastAPI HTTP/WebSocket server, Telegram bot |
 | **Customization** | TOML config, YAML agent specs, slash commands, reusable skills, hooks, event bus |
 | **Model support** | OpenAI Chat Completions, OpenAI Responses API, Anthropic Claude, and OpenAI-compatible endpoints |
 
@@ -129,13 +129,6 @@ amcp attach http://localhost:4096       # connect to a running server
 amcp telegram start                     # start polling
 amcp telegram status                    # show config status
 amcp telegram setup                     # interactive setup
-
-# Automation / cron jobs
-amcp cron list                          # list scheduled jobs
-amcp cron add                           # add a new job
-amcp cron run <job-name>                # run a job immediately
-amcp cron enable <job-name>             # enable a job
-amcp cron disable <job-name>            # disable a job
 
 ```
 
@@ -276,20 +269,6 @@ AMCP provides a Telegram Bot interface for remote interaction with agents. Insta
 
 Configure via `amcp telegram setup` or in `config.toml` under `[telegram]`.
 
-## Automation / Cron Jobs
-
-AMCP supports scheduled automation jobs designed for external orchestrators (systemd, cron, K8s):
-
-```bash
-amcp cron list                # list configured jobs
-amcp cron add                 # add a new job interactively
-amcp cron run ci-check        # execute a job once
-amcp cron enable ci-check     # enable a job
-amcp cron disable ci-check    # disable a job
-```
-
-Jobs are defined in `config.toml` under `[automation.jobs]` and can reference skills or custom prompts with cron schedules.
-
 ## Memory System
 
 AMCP maintains persistent cross-session memory using a two-layer approach:
@@ -410,21 +389,6 @@ code_ttl_seconds = 1800
 
 The Telegram runtime also supports group-specific and topic-specific policy overrides under
 `[telegram.groups."<chat_id>"]` and `[telegram.groups."<chat_id>".topics."<topic_id>"]`.
-
-### Automation Configuration
-
-```toml
-[automation]
-enabled = true
-default_timeout = 300
-
-[[automation.jobs]]
-name = "ci-check"
-command = "Run tests and lint checks"
-schedule = "0 9 * * 1-5"       # weekdays at 9 AM
-enabled = true
-timeout = 600
-```
 
 ## Development
 

--- a/src/amcp/cli.py
+++ b/src/amcp/cli.py
@@ -25,8 +25,6 @@ from .agent_spec import get_default_agent_spec, list_available_agents, load_agen
 from .commands import get_command_manager
 from .config import (
     AMCPConfig,
-    AutomationConfig,
-    AutomationJobConfig,
     load_config,
     save_config,
     save_default_config,
@@ -105,151 +103,6 @@ app.add_typer(acp, name="acp")
 
 telegram = typer.Typer(help="Telegram bot utilities")
 app.add_typer(telegram, name="telegram")
-
-cron_cli = typer.Typer(help="Automation job management (external scheduler friendly)")
-app.add_typer(cron_cli, name="cron")
-
-
-def _get_configured_jobs(cfg: AMCPConfig) -> list[AutomationJobConfig]:
-    """Return configured jobs from [automation.jobs]."""
-    if cfg.automation and cfg.automation.jobs:
-        return cfg.automation.jobs
-    return []
-
-
-# ---------------------------------------------------------------------------
-# Cron commands
-# ---------------------------------------------------------------------------
-
-
-@cron_cli.command("list", help="List scheduled cron jobs")
-def cron_list() -> None:
-    """List all configured cron jobs."""
-    cfg = load_config()
-    jobs = _get_configured_jobs(cfg)
-    if not jobs:
-        console.print("[yellow]No cron jobs configured[/yellow]")
-        console.print("[dim]Add jobs in config.toml under [[automation.jobs]] (recommended).[/dim]")
-        return
-
-    table = Table(title="Cron Jobs")
-    table.add_column("Name", style="cyan")
-    table.add_column("Schedule", style="magenta")
-    table.add_column("Enabled", style="green")
-    table.add_column("Notify", style="yellow")
-    table.add_column("Timeout", style="blue")
-    table.add_column("Command", style="white", max_width=40)
-
-    for job in jobs:
-        schedule = getattr(job, "schedule", None) or "-"
-        table.add_row(
-            job.name,
-            schedule,
-            "✅" if job.enabled else "❌",
-            "🔔" if job.notify else "🔕",
-            f"{job.timeout}s",
-            job.command[:40] + ("…" if len(job.command) > 40 else ""),
-        )
-
-    console.print(table)
-
-
-@cron_cli.command("add", help="Add a new cron job")
-def cron_add(
-    name: Annotated[str, typer.Argument(help="Job name")],
-    command: Annotated[str, typer.Option("--command", "-c", help="Agent command to run")],
-    schedule: Annotated[
-        str | None,
-        typer.Option(
-            "--schedule",
-            "-s",
-            help="Legacy cron expression (recommended: schedule externally via systemd/cron/K8s)",
-        ),
-    ] = None,
-    notify: Annotated[bool, typer.Option("--notify", help="Send notification on completion")] = True,
-    timeout: Annotated[int, typer.Option("--timeout", help="Timeout in seconds")] = 300,
-    skill: Annotated[str | None, typer.Option("--skill", help="Skill to activate")] = None,
-) -> None:
-    """Add a new automation job to the config."""
-
-    cfg = load_config()
-    if cfg.automation is None:
-        cfg.automation = AutomationConfig()
-
-    new_job = AutomationJobConfig(
-        name=name,
-        command=command,
-        notify=notify,
-        timeout=timeout,
-        skill=skill,
-        schedule=schedule,
-    )
-    cfg.automation.jobs.append(new_job)
-    save_config(cfg)
-    schedule_msg = f" (schedule: {schedule})" if schedule else ""
-    console.print(f"[green]Added automation job '{name}'{schedule_msg}[/green]")
-
-
-@cron_cli.command("run", help="Run a cron job immediately")
-def cron_run(
-    name: Annotated[str, typer.Argument(help="Job name to run")],
-) -> None:
-    """Run an automation job immediately."""
-    cfg = load_config()
-    jobs = _get_configured_jobs(cfg)
-    if not jobs:
-        console.print("[red]No cron jobs configured[/red]")
-        raise typer.Exit(1)
-
-    job_cfg = next((j for j in jobs if j.name == name), None)
-    if not job_cfg:
-        console.print(f"[red]Job '{name}' not found[/red]")
-        raise typer.Exit(1)
-
-    console.print(f"[green]Running job '{name}'...[/green]")
-    console.print(f"[dim]Command: {job_cfg.command}[/dim]")
-
-    agent = Agent()
-    if getattr(job_cfg, "skill", None):
-        get_skill_manager().activate_skill(job_cfg.skill)
-
-    work_dir = Path(job_cfg.work_dir) if job_cfg.work_dir else None
-    result = asyncio.run(agent.run(job_cfg.command, work_dir=work_dir))
-    console.print(Panel(Markdown(result), title=f"Job: {name}", border_style="green"))
-
-
-@cron_cli.command("enable", help="Enable a cron job")
-def cron_enable(name: Annotated[str, typer.Argument(help="Job name")]) -> None:
-    cfg = load_config()
-    jobs = _get_configured_jobs(cfg)
-    if not jobs:
-        console.print("[red]No cron jobs configured[/red]")
-        raise typer.Exit(1)
-    for job in jobs:
-        if job.name == name:
-            job.enabled = True
-            save_config(cfg)
-            console.print(f"[green]Enabled job '{name}'[/green]")
-            return
-    console.print(f"[red]Job '{name}' not found[/red]")
-    raise typer.Exit(1)
-
-
-@cron_cli.command("disable", help="Disable a cron job")
-def cron_disable(name: Annotated[str, typer.Argument(help="Job name")]) -> None:
-    cfg = load_config()
-    jobs = _get_configured_jobs(cfg)
-    if not jobs:
-        console.print("[red]No cron jobs configured[/red]")
-        raise typer.Exit(1)
-    for job in jobs:
-        if job.name == name:
-            job.enabled = False
-            save_config(cfg)
-            console.print(f"[green]Disabled job '{name}'[/green]")
-            return
-    console.print(f"[red]Job '{name}' not found[/red]")
-    raise typer.Exit(1)
 
 
 @acp.command("serve", help="Run AMCP as an ACP-compliant agent server (stdio transport)")
@@ -451,14 +304,12 @@ def serve_command(
 
     This allows remote clients to connect and interact with AMCP agents.
     AMCP does not start in-process daemon background orchestration.
-    Use external orchestrators (systemd/cron/K8s) and `amcp cron run` for jobs.
 
     Examples:
         amcp serve                          # Start on localhost:4096
         amcp serve --port 8080             # Use custom port
         amcp serve --host 0.0.0.0          # Listen on all interfaces
         amcp serve -w /path/to/project     # Set default working directory
-        amcp cron run ci-check             # Execute automation job once (for systemd/cron/K8s)
 
     API Documentation:
         Once running, visit http://localhost:4096/docs for API docs.
@@ -474,7 +325,6 @@ def serve_command(
         _start_telegram_bot(work_dir)
 
     console.print("[green]Running without in-process daemon background orchestration.[/green]")
-    console.print("[dim]Use systemd/cron/K8s + `amcp cron run <job>` for automation.[/dim]")
 
     run_server(
         host=host,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -195,4 +195,8 @@ class TestMakeClient:
             mock_openai = MagicMock()
             mock_import.return_value = MagicMock(OpenAI=mock_openai)
             _make_client("https://api.example.com/v1", "test-key")
-            mock_openai.assert_called_once_with(base_url="https://api.example.com/v1", api_key="test-key")
+            mock_openai.assert_called_once_with(
+                base_url="https://api.example.com/v1",
+                api_key="test-key",
+                default_headers={"User-Agent": "AMCPAgent"},
+            )


### PR DESCRIPTION
# Pull Request

## Description
Remove the misleading `amcp cron` CLI surface. The command only managed AMCP-local automation job config and did not install or manage system cron entries, while Telegram assistant-mode scheduling continues to use skill `triggers.schedule` through `AssistantScheduler`.

This also removes README references to the deleted cron CLI and scheduled automation jobs, and updates the OpenAI client unit test to match the existing default User-Agent header behavior that CI validates in the full test suite.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Testing

```bash
.venv/bin/ruff check src/amcp/cli.py
.venv/bin/ruff check src/amcp/cli.py tests/test_chat.py
.venv/bin/python -m pytest tests/test_assistant_scheduler.py tests/test_commands.py -q
.venv/bin/python -m pytest tests/test_chat.py::TestMakeClient::test_creates_client tests/test_assistant_scheduler.py tests/test_commands.py -q
.venv/bin/amcp --help
.venv/bin/amcp cron --help
```

## Related Issues
None.
