### PR TITLE
Add Telegram provider switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,9 +319,7 @@ amcp init
 
 ```toml
 [chat]
-api_type = "openai"            # "openai" (default), "openai_responses", or "anthropic"
-base_url = "https://example.com/v1"
-model = "provider/model-name"
+active_provider = "primary"    # optional: selected [chat.providers.<name>] profile
 mcp_tools_enabled = true
 write_tool_enabled = true
 edit_tool_enabled = true
@@ -329,7 +327,21 @@ tool_loop_limit = 300
 default_max_lines = 400
 default_agent = "coder"        # optional: coder, explorer, planner, focused_coder
 max_queue_size = 100
+
+[chat.providers.primary]
+api_type = "openai"
+base_url = "https://example.com/v1"
+model = "provider/model-name"
+
+[chat.providers.backup]
+api_type = "anthropic"
+model = "claude-model-name"
 ```
+
+Telegram can switch configured providers without calling the LLM:
+
+- `/models` lists configured provider profiles.
+- `/model use backup` switches `active_provider` and persists it to `config.toml` (admin only).
 
 **Anthropic Claude:**
 ```toml

--- a/src/amcp/__init__.py
+++ b/src/amcp/__init__.py
@@ -54,6 +54,7 @@ __all__ = [
     # Config
     "AMCPConfig",
     "ChatConfig",
+    "ChatProviderConfig",
     "ContextConfig",
     "ModelConfig",
     "TelegramConfig",
@@ -122,6 +123,7 @@ from .compaction import (
 from .config import (
     AMCPConfig,
     ChatConfig,
+    ChatProviderConfig,
     ContextConfig,
     ModelConfig,
     TelegramConfig,

--- a/src/amcp/config.py
+++ b/src/amcp/config.py
@@ -59,6 +59,17 @@ class ModelConfig:
 
 
 @dataclass
+class ChatProviderConfig:
+    """Named LLM provider profile for runtime switching."""
+
+    base_url: str | None = None
+    model: str | None = None
+    api_key: str | None = None
+    api_type: str | None = None  # "openai" (default), "openai_responses", or "anthropic"
+    model_config: ModelConfig | None = None
+
+
+@dataclass
 class ChatConfig:
     base_url: str | None = None
     model: str | None = None
@@ -67,6 +78,11 @@ class ChatConfig:
 
     # Model configuration (from models.dev or custom)
     model_config: ModelConfig | None = None
+
+    # Named provider profiles. ``active_provider`` selects which profile is copied
+    # into the top-level chat fields at load time so existing call sites keep working.
+    active_provider: str | None = None
+    providers: dict[str, ChatProviderConfig] = field(default_factory=dict)
 
     # Tool calling settings
     tool_loop_limit: int | None = None
@@ -177,6 +193,14 @@ _DEFAULT = {
     "chat": {
         "base_url": "https://inference.baseten.co/v1",
         "model": "zai-org/GLM-4.6",
+        "active_provider": "baseten",
+        "providers": {
+            "baseten": {
+                "base_url": "https://inference.baseten.co/v1",
+                "model": "zai-org/GLM-4.6",
+                "api_type": "openai",
+            },
+        },
         # "api_key": ""  # optional; users can add this if they want config-based auth
         "tool_loop_limit": 300,
         "bash_tool_limit": 100,
@@ -281,6 +305,38 @@ def _decode_model_config(raw: Mapping[str, object] | None) -> ModelConfig | None
     )
 
 
+def _decode_chat_provider(raw: Mapping[str, object]) -> ChatProviderConfig:
+    """Decode a named chat provider profile from TOML."""
+    base_url = raw.get("base_url")
+    model = raw.get("model")
+    api_key = raw.get("api_key")
+    api_type = raw.get("api_type")
+    raw_model_config = raw.get("model_config")
+    model_config = _decode_model_config(raw_model_config) if isinstance(raw_model_config, dict) else None
+    return ChatProviderConfig(
+        base_url=str(base_url) if base_url is not None else None,
+        model=str(model) if model is not None else None,
+        api_key=str(api_key) if api_key is not None else None,
+        api_type=str(api_type) if api_type is not None else None,
+        model_config=model_config,
+    )
+
+
+def _apply_active_provider(chat: ChatConfig) -> ChatConfig:
+    """Copy the selected provider profile into top-level chat fields."""
+    if not chat.active_provider:
+        return chat
+    provider = chat.providers.get(chat.active_provider)
+    if provider is None:
+        return chat
+    chat.base_url = provider.base_url
+    chat.model = provider.model
+    chat.api_key = provider.api_key
+    chat.api_type = provider.api_type
+    chat.model_config = provider.model_config
+    return chat
+
+
 def _decode_chat(raw: Mapping[str, object] | None) -> ChatConfig | None:
     if not raw:
         return None
@@ -305,12 +361,22 @@ def _decode_chat(raw: Mapping[str, object] | None) -> ChatConfig | None:
     raw_model_config = raw.get("model_config")
     model_config = _decode_model_config(raw_model_config) if isinstance(raw_model_config, dict) else None
 
-    return ChatConfig(
+    active_provider = raw.get("active_provider")
+    raw_providers = raw.get("providers")
+    providers: dict[str, ChatProviderConfig] = {}
+    if isinstance(raw_providers, dict):
+        for name, provider_raw in raw_providers.items():
+            if isinstance(provider_raw, dict):
+                providers[str(name)] = _decode_chat_provider(provider_raw)
+
+    chat = ChatConfig(
         base_url=str(base_url) if base_url is not None else None,
         model=str(model) if model is not None else None,
         api_key=str(api_key) if api_key is not None else None,
         api_type=str(api_type) if api_type is not None else None,
         model_config=model_config,
+        active_provider=str(active_provider) if active_provider is not None else None,
+        providers=providers,
         tool_loop_limit=int(str(tool_loop_limit)) if tool_loop_limit is not None else None,
         bash_tool_limit=int(str(bash_tool_limit)) if bash_tool_limit is not None else None,
         default_max_lines=int(str(default_max_lines)) if default_max_lines is not None else None,
@@ -323,6 +389,7 @@ def _decode_chat(raw: Mapping[str, object] | None) -> ChatConfig | None:
         enable_queue=bool(enable_queue) if enable_queue is not None else None,
         max_queue_size=int(str(max_queue_size)) if max_queue_size is not None else None,
     )
+    return _apply_active_provider(chat)
 
 
 def _decode_context(raw: Mapping[str, object] | None) -> ContextConfig | None:
@@ -510,22 +577,44 @@ def _encode_model_config(m: ModelConfig | None) -> dict | None:
     return out if out else None
 
 
+def _encode_chat_provider(p: ChatProviderConfig) -> dict:
+    """Encode a named chat provider profile to TOML-compatible dict."""
+    out: dict = {}
+    if p.base_url:
+        out["base_url"] = p.base_url
+    if p.model:
+        out["model"] = p.model
+    if p.api_key:
+        out["api_key"] = p.api_key
+    if p.api_type:
+        out["api_type"] = p.api_type
+    model_config_dict = _encode_model_config(p.model_config)
+    if model_config_dict:
+        out["model_config"] = model_config_dict
+    return out
+
+
 def _encode_chat(c: ChatConfig | None) -> dict | None:
     if c is None:
         return None
     out: dict = {}
-    if c.base_url:
+    provider_profiles_enabled = bool(c.providers)
+    if c.base_url and not provider_profiles_enabled:
         out["base_url"] = c.base_url
-    if c.model:
+    if c.model and not provider_profiles_enabled:
         out["model"] = c.model
-    if c.api_key:
+    if c.api_key and not provider_profiles_enabled:
         out["api_key"] = c.api_key
-    if c.api_type:
+    if c.api_type and not provider_profiles_enabled:
         out["api_type"] = c.api_type
     # Model config
     model_config_dict = _encode_model_config(c.model_config)
-    if model_config_dict:
+    if model_config_dict and not provider_profiles_enabled:
         out["model_config"] = model_config_dict
+    if c.active_provider:
+        out["active_provider"] = c.active_provider
+    if c.providers:
+        out["providers"] = {name: _encode_chat_provider(provider) for name, provider in c.providers.items()}
     if c.tool_loop_limit is not None:
         out["tool_loop_limit"] = int(c.tool_loop_limit)
     if c.bash_tool_limit is not None:

--- a/src/amcp/init_wizard.py
+++ b/src/amcp/init_wizard.py
@@ -18,6 +18,7 @@ from .config import (
     CONFIG_FILE,
     AMCPConfig,
     ChatConfig,
+    ChatProviderConfig,
     ModelConfig,
     Server,
     save_config,
@@ -559,7 +560,18 @@ def run_init_wizard() -> Path:
         base_url=base_url,
         model=model_id,
         api_key=api_key if api_key else None,
+        api_type="openai",
         model_config=model_config,
+        active_provider=provider_id,
+        providers={
+            provider_id: ChatProviderConfig(
+                base_url=base_url,
+                model=model_id,
+                api_key=api_key if api_key else None,
+                api_type="openai",
+                model_config=model_config,
+            )
+        },
         tool_loop_limit=300,
         bash_tool_limit=100,
         default_max_lines=400,

--- a/src/amcp/telegram/bot.py
+++ b/src/amcp/telegram/bot.py
@@ -188,6 +188,66 @@ class TelegramBot:
         except ValueError:
             return False, f"Invalid value for {key}."
 
+    def models_summary(self) -> str:
+        """Return a user-facing summary of configured LLM provider profiles."""
+        cfg = load_config()
+        chat = cfg.chat
+        if chat is None:
+            return "No chat configuration found."
+
+        if not chat.providers:
+            lines = ["Configured providers:", "* current"]
+            if chat.model:
+                lines[-1] += f" — model={chat.model}"
+            if chat.base_url:
+                lines[-1] += f" — base_url={chat.base_url}"
+            lines.append("Add [chat.providers.<name>] entries to config.toml to enable switching.")
+            return "\n".join(lines)
+
+        lines = ["Configured providers:"]
+        for name, provider in sorted(chat.providers.items()):
+            marker = "*" if name == chat.active_provider else "-"
+            details = []
+            if provider.api_type:
+                details.append(f"api_type={provider.api_type}")
+            if provider.model:
+                details.append(f"model={provider.model}")
+            if provider.base_url:
+                details.append(f"base_url={provider.base_url}")
+            suffix = f" — {'; '.join(details)}" if details else ""
+            lines.append(f"{marker} {name}{suffix}")
+        lines.append("Use /model use <name> to switch provider.")
+        return "\n".join(lines)
+
+    def use_model_provider(self, name: str) -> tuple[bool, str]:
+        """Switch the active LLM provider profile and persist it to config.toml."""
+        provider_name = name.strip()
+        if not provider_name:
+            return False, "Usage: /model use <name>"
+
+        cfg = load_config()
+        if cfg.chat is None:
+            return False, "No chat configuration found."
+        provider = cfg.chat.providers.get(provider_name)
+        if provider is None:
+            available = ", ".join(sorted(cfg.chat.providers)) or "none"
+            return False, f"Unknown provider: {provider_name}. Available: {available}"
+
+        cfg.chat.active_provider = provider_name
+        cfg.chat.base_url = provider.base_url
+        cfg.chat.model = provider.model
+        cfg.chat.api_key = provider.api_key
+        cfg.chat.api_type = provider.api_type
+        cfg.chat.model_config = provider.model_config
+        path = save_config(cfg)
+        try:
+            path.chmod(0o600)
+        except OSError:
+            logger.warning("Failed to set config file permissions.")
+        model = provider.model or "unset"
+        api_type = provider.api_type or "openai"
+        return True, f"Switched provider to {provider_name} (api_type={api_type}, model={model})."
+
     async def persist_config(self) -> None:
         cfg = load_config()
         cfg.telegram = self._config
@@ -441,6 +501,8 @@ class TelegramBot:
         application.add_handler(CommandHandler("skills", self._handlers.handle_skills))
         application.add_handler(CommandHandler("activate", self._handlers.handle_activate))
         application.add_handler(CommandHandler("memory", self._handlers.handle_memory))
+        application.add_handler(CommandHandler("models", self._handlers.handle_models))
+        application.add_handler(CommandHandler("model", self._handlers.handle_model))
         application.add_handler(CommandHandler("config", self._handlers.handle_config))
         application.add_handler(CommandHandler("users", self._handlers.handle_users))
         application.add_handler(CommandHandler("pair", self._handlers.handle_pair))
@@ -486,6 +548,7 @@ class TelegramBot:
             BotCommand("new", "Start a new conversation session"),
             BotCommand("session", "Manage sessions (new|list|switch)"),
             BotCommand("skills", "List and manage skills"),
+            BotCommand("models", "List configured LLM providers"),
         ]
 
     async def _post_init(self, application: Application) -> None:

--- a/src/amcp/telegram/handlers.py
+++ b/src/amcp/telegram/handlers.py
@@ -553,6 +553,8 @@ class TelegramHandlers:
             "/activate <skill> - Activate a skill",
             "/skill:<name> [param=value ...] - Invoke a skill explicitly",
             "/memory search <query> - Search memory",
+            "/models - List configured LLM providers",
+            "/model use <name> - Switch LLM provider (admin)",
             "/config show|set <key> <value> - View/update config (admin)",
             "/users list|add|remove <id> - Manage users (admin)",
             "/logs <n> - Show recent logs (admin)",
@@ -741,6 +743,23 @@ class TelegramHandlers:
         for idx, result in enumerate(results, start=1):
             lines.append(f"{idx}. [{result.source}] {result.line_number}: {result.content}")
         await self._bot.send_text(update.effective_chat.id, "\n".join(lines))
+
+    async def handle_models(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """List configured LLM provider profiles."""
+        if not await self._ensure_authorized(update):
+            return
+        await self._bot.send_text(update.effective_chat.id, self._bot.models_summary())
+
+    async def handle_model(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Switch the active LLM provider profile."""
+        if not await self._ensure_admin(update):
+            return
+        args = context.args or []
+        if len(args) >= 2 and args[0].lower() == "use":
+            _, message = self._bot.use_model_provider(" ".join(args[1:]))
+            await self._bot.send_text(update.effective_chat.id, message)
+            return
+        await self._bot.send_text(update.effective_chat.id, "Usage: /model use <name>")
 
     async def handle_config(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         if not await self._ensure_admin(update):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,6 +58,49 @@ def test_decode_encode_chat_tool_limits_roundtrip():
     assert encoded["bash_tool_limit"] == 100
 
 
+def test_decode_chat_active_provider_applies_profile():
+    raw = {
+        "base_url": "https://primary.example/v1",
+        "model": "primary-model",
+        "active_provider": "backup",
+        "providers": {
+            "primary": {
+                "base_url": "https://primary.example/v1",
+                "model": "primary-model",
+                "api_type": "openai",
+            },
+            "backup": {
+                "base_url": "https://backup.example/v1",
+                "model": "backup-model",
+                "api_type": "anthropic",
+                "model_config": {
+                    "provider_id": "anthropic",
+                    "model_id": "backup-model",
+                    "context_window": 200000,
+                },
+            },
+        },
+    }
+
+    cfg = config_module._decode_chat(raw)
+    assert cfg is not None
+    assert cfg.active_provider == "backup"
+    assert cfg.base_url == "https://backup.example/v1"
+    assert cfg.model == "backup-model"
+    assert cfg.api_type == "anthropic"
+    assert cfg.model_config is not None
+    assert cfg.model_config.provider_id == "anthropic"
+
+    encoded = config_module._encode_chat(cfg)
+    assert encoded is not None
+    assert encoded["active_provider"] == "backup"
+    assert encoded["providers"]["backup"]["model"] == "backup-model"
+    assert "base_url" not in encoded
+    assert "model" not in encoded
+    assert "api_type" not in encoded
+    assert "model_config" not in encoded
+
+
 def test_decode_encode_automation_roundtrip():
     raw = {
         "enabled": True,

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -28,6 +28,7 @@ class _FakeBot:
         self.pairing_requests: list[tuple[int, int, str | None]] = []
         self.sent_texts: list[tuple[int, str]] = []
         self.prompts: list[tuple[int, int, str]] = []
+        self.model_provider_requests: list[str] = []
 
     def create_pairing_request(self, user_id: int, chat_id: int, username: str | None = None):
         self.pairing_requests.append((user_id, chat_id, username))
@@ -41,6 +42,13 @@ class _FakeBot:
 
     def cancel_session(self, chat_id: int):
         return False, False
+
+    def models_summary(self) -> str:
+        return "Configured providers:\n* test"
+
+    def use_model_provider(self, name: str):
+        self.model_provider_requests.append(name)
+        return True, f"Switched provider to {name}."
 
 
 def test_auth_middleware():
@@ -132,6 +140,41 @@ def test_handle_session_switch_uses_shared_session_command():
         await handlers.handle_session(update, SimpleNamespace(args=["switch", session.session_id]))
 
         assert fake_bot.sent_texts[-1] == (123, f"Switched to session: {session.session_id}")
+
+    asyncio.run(_run())
+
+
+def test_handle_models_lists_configured_providers():
+    async def _run():
+        handlers, fake_bot = _make_handlers(TelegramConfig(), allowed_users={42})
+        message = _make_message(text="/models", user_id=42)
+        update = SimpleNamespace(
+            effective_chat=message.chat,
+            effective_user=message.from_user,
+            message=message,
+        )
+
+        await handlers.handle_models(update, SimpleNamespace(args=[]))
+
+        assert fake_bot.sent_texts[-1] == (123, "Configured providers:\n* test")
+
+    asyncio.run(_run())
+
+
+def test_handle_model_use_switches_provider_for_admin():
+    async def _run():
+        handlers, fake_bot = _make_handlers(TelegramConfig(), allowed_users={42}, admin_users={42})
+        message = _make_message(text="/model use backup", user_id=42)
+        update = SimpleNamespace(
+            effective_chat=message.chat,
+            effective_user=message.from_user,
+            message=message,
+        )
+
+        await handlers.handle_model(update, SimpleNamespace(args=["use", "backup"]))
+
+        assert fake_bot.model_provider_requests == ["backup"]
+        assert fake_bot.sent_texts[-1] == (123, "Switched provider to backup.")
 
     asyncio.run(_run())
 
@@ -270,13 +313,17 @@ def test_build_enriched_prompt_with_reply():
     assert reply["from_is_bot"] is True
 
 
-def _make_handlers(config: TelegramConfig, allowed_users: set[int] | None = None):
+def _make_handlers(
+    config: TelegramConfig,
+    allowed_users: set[int] | None = None,
+    admin_users: set[int] | None = None,
+):
     fake_bot = _FakeBot(config)
     manager = SessionManager(agent_factory=_FakeAgent, session_timeout=60)
     handlers = TelegramHandlers(
         bot=fake_bot,
         session_manager=manager,
-        auth=AuthMiddleware(allowed_users=allowed_users or set(), admin_users=set()),
+        auth=AuthMiddleware(allowed_users=allowed_users or set(), admin_users=admin_users or set()),
         rate_limiter=RateLimiter(limit=100),
     )
     return handlers, fake_bot
@@ -388,10 +435,10 @@ def test_post_init_registers_user_facing_bot_commands():
         names = [c.command for c in commands]
 
         # user-facing commands registered in the menu
-        for expected in ["start", "help", "status", "new", "session", "skills"]:
+        for expected in ["start", "help", "status", "new", "session", "skills", "models"]:
             assert expected in names
         # admin and helper commands intentionally omitted
-        for omitted in ["cancel", "ask", "activate", "memory", "config", "users", "pair", "logs", "shutdown"]:
+        for omitted in ["cancel", "ask", "activate", "memory", "model", "config", "users", "pair", "logs", "shutdown"]:
             assert omitted not in names
 
     asyncio.run(_run())
@@ -404,7 +451,7 @@ def test_get_user_bot_commands_descriptions():
         mock_bot_command.side_effect = lambda cmd, desc: SimpleNamespace(command=cmd, description=desc)
         commands = bot._get_user_bot_commands()
 
-    assert [c.command for c in commands] == ["start", "help", "status", "new", "session", "skills"]
+    assert [c.command for c in commands] == ["start", "help", "status", "new", "session", "skills", "models"]
     for command in commands:
         assert command.description  # non-empty
 


### PR DESCRIPTION
# Pull Request

## Description
Adds runtime LLM provider switching for long-running Telegram deployments.

This change introduces named chat provider profiles under `[chat.providers.<name>]`, with `[chat].active_provider` selecting the profile to use. The config loader applies the active profile to the in-memory `ChatConfig` so existing CLI, server, ACP, and agent LLM paths continue to use `cfg.chat.model/base_url/api_key/api_type` without needing call-site rewrites.

Telegram gains:
- `/models` to list configured provider profiles.
- `/model use <name>` for admins to switch the active provider and persist the change.

Provider add/remove remains config-file based, so agents or operators can edit `config.toml` directly.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Testing

```bash
.venv/bin/ruff format src tests
.venv/bin/ruff check src tests
.venv/bin/python -m pytest -q
bash -n e2b/start-sandbox.sh e2b/launch-ready-sandbox.sh e2b/validate-sandbox.sh
```

## Related Issues

N/A
