### PR TITLE
ci: publish Docker image to GHCR

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,63 @@
+name: Docker Image
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel in-progress runs for the same branch/tag/PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build and publish image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and publish Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,27 +12,37 @@
 #   docker run -p 4096:4096 -v ./config.toml:/root/.config/amcp/config.toml \
 #       amcp serve --host 0.0.0.0 --scheduler --reactor
 
-FROM python:3.12-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    PATH="/app/.venv/bin:${PATH}"
 
 WORKDIR /app
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ripgrep \
     git \
+    curl \
+    ca-certificates \
+    tini \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy project files
-COPY . .
+# Copy only files needed to install AMCP. Avoid sending local deployment
+# files (for example e2b/env) into the runtime image and keep dependency
+# installation cacheable across unrelated repository changes.
+COPY pyproject.toml uv.lock README.md ./
+COPY src ./src
 
 # Install Python dependencies
-RUN pip install --no-cache-dir -e .
+RUN uv sync --frozen --no-dev --no-editable
 
-# Create config directory
-RUN mkdir -p /root/.config/amcp
+# Create runtime directories
+RUN mkdir -p /root/.config/amcp /workspace
 
-# Set environment variables
-ENV PYTHONUNBUFFERED=1
+WORKDIR /workspace
 
 # Health check — hits the server /api/v1/health endpoint
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
@@ -40,5 +50,5 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 
 EXPOSE 4096
 
-ENTRYPOINT ["amcp"]
+ENTRYPOINT ["/usr/bin/tini", "--", "amcp"]
 CMD ["serve", "--host", "0.0.0.0"]


### PR DESCRIPTION
# Pull Request

## Description
Adds a Docker image workflow that builds the root Dockerfile on PRs and publishes the image to GitHub Container Registry on pushes to `main` and version tags.

Also optimizes the root Dockerfile for the server image by installing from `uv.lock`, copying only package/runtime files into the image, using `tini`, and avoiding local deployment files such as `e2b/env` in the image context.

Published image:

```text
ghcr.io/tao12345666333/amcp
```

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Testing

```bash
docker build -t amcp-root-dockerfile-check .
docker run --rm amcp-root-dockerfile-check --help
python - <<'PY'
from pathlib import Path
import yaml
for path in Path('.github/workflows').glob('*.yml'):
    with path.open() as f:
        yaml.safe_load(f)
    print(f'ok {path}')
PY
```

## Related Issues

None.
