### PR TITLE
fix: prevent context overflow and report Telegram usage

### DIFF
--- a/src/amcp/agent.py
+++ b/src/amcp/agent.py
@@ -18,7 +18,13 @@ from rich.text import Text
 
 from .agent_spec import ResolvedAgentSpec, get_default_agent_spec
 from .chat import _make_client, _resolve_api_key, _resolve_base_url
-from .compaction import SmartCompactor, estimate_tokens
+from .compaction import (
+    CompactionConfig,
+    SmartCompactor,
+    estimate_request_tokens,
+    estimate_tokens,
+    get_model_context_window,
+)
 from .config import AMCPConfig, ContextConfig, ModelConfig, load_config
 from .hooks import (
     HookDecision,
@@ -623,29 +629,37 @@ class Agent:
                 system_prompt = self._get_system_prompt(work_dir, user_input=user_input)
                 messages = [{"role": "system", "content": system_prompt}]
 
-                # Add conversation history with compaction if needed
+                # Build tools before compaction so their schemas are included in
+                # the request-size decision.
                 history_to_add = list(self.conversation_history)
+                tools, tool_registry = await self._build_tools_and_registry(
+                    user_input=user_input,
+                    conversation_history=history_to_add,
+                )
 
                 # Apply compaction if context is too large
                 cfg = load_config()
                 base_url = _resolve_base_url(self.agent_spec.base_url or None, cfg.chat)
                 api_key = _resolve_api_key(None, cfg.chat)
                 client = _make_client(base_url, api_key)
-                model = cfg.chat.model if cfg.chat and cfg.chat.model else "DeepSeek-V3.1-Terminus"
+                model = self._resolve_model_name(cfg)
                 compactor = SmartCompactor(
                     client,
                     model,
                     model_config=cfg.chat.model_config if cfg.chat else None,
                 )
 
-                if compactor.should_compact(history_to_add):
+                request_tokens = estimate_request_tokens(messages + history_to_add, tools)
+                if (
+                    request_tokens > compactor.threshold_tokens
+                    and estimate_tokens(history_to_add) >= compactor.config.min_tokens_to_compact
+                ):
                     # Pre-compaction memory flush: save durable memories before
                     # context is summarized (inspired by openclaw's memory flush).
                     status.update(f"[bold]Agent {self.name}[/bold] saving memories before compaction...")
                     await self._run_memory_review(
                         conversation_snapshot=history_to_add,
                         system_prompt=system_prompt,
-                        tools=None,  # will be built below
                         work_dir=work_dir,
                         status=status,
                     )
@@ -655,12 +669,6 @@ class Agent:
                     self.console.print("[dim]Context compacted to reduce token usage[/dim]")
 
                 messages.extend(history_to_add)
-
-                # Build tools and registry (combined to avoid duplicate MCP calls)
-                tools, tool_registry = await self._build_tools_and_registry(
-                    user_input=user_input,
-                    conversation_history=history_to_add,
-                )
 
                 # Run chat with tools
                 result = await self._run_with_tools(
@@ -710,7 +718,6 @@ class Agent:
         self,
         conversation_snapshot: list[dict[str, Any]],
         system_prompt: str,
-        tools: list[dict[str, Any]] | None,
         work_dir: Path | None,
         status: Any = None,
     ) -> None:
@@ -976,8 +983,17 @@ class Agent:
         self.current_request_llm_calls = 0
 
         # Create a working copy of messages
-        messages = list(messages)
+        messages = [dict(message) for message in messages]
         used_tools = False
+
+        cfg = load_config()
+        model_config = cfg.chat.model_config if cfg.chat else None
+        model = getattr(llm_client, "model", None) or self._resolve_model_name(cfg)
+        compaction_config = CompactionConfig()
+        context_window = get_model_context_window(model, model_config=model_config)
+        input_token_budget = int(
+            context_window * (1 - compaction_config.safety_margin) * compaction_config.threshold_ratio
+        )
 
         for step in range(max_steps):
             self.step_count = step + 1
@@ -995,6 +1011,7 @@ class Agent:
 
                 stream_callback = _stream_callback
 
+            messages = self._fit_tool_context(messages, tools, input_token_budget)
             resp = llm_client.chat(messages=messages, tools=tools, stream_callback=stream_callback)
 
             if resp.tool_calls:
@@ -1023,6 +1040,7 @@ class Agent:
                     )
                     # Get a final response from the LLM with the current messages
                     try:
+                        messages = self._fit_tool_context(messages, [], input_token_budget)
                         final_resp = llm_client.chat(messages=messages)
                         final_text = final_resp.content or ""
                         status.update(f"[bold]Agent {self.name}[/bold] - ✅ Complete")
@@ -1030,6 +1048,24 @@ class Agent:
                     except Exception as e:
                         status.update(f"[bold]Agent {self.name}[/bold] - ⚠️ Error getting final response")
                         return f"Error: Could not get final response: {e}"
+
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": resp.content or "",
+                        "tool_calls": [
+                            {
+                                "id": tc["id"],
+                                "type": "function",
+                                "function": {
+                                    "name": tc["name"],
+                                    "arguments": tc["arguments"] or "{}",
+                                },
+                            }
+                            for tc in tool_calls
+                        ],
+                    }
+                )
 
                 # Process tool calls with Live UI
                 with LiveUI() as live_ui:
@@ -1192,19 +1228,6 @@ class Agent:
 
                             messages.append(
                                 {
-                                    "role": "assistant",
-                                    "content": resp.content or "",
-                                    "tool_calls": [
-                                        {
-                                            "id": tool_id,
-                                            "type": "function",
-                                            "function": {"name": tool_name, "arguments": tc["arguments"] or "{}"},
-                                        }
-                                    ],
-                                }
-                            )
-                            messages.append(
-                                {
                                     "role": "tool",
                                     "tool_call_id": tool_id,
                                     "name": tool_name,
@@ -1254,6 +1277,60 @@ class Agent:
         # Max steps reached
         status.update(f"[bold]Agent {self.name}[/bold] - ⚠️ Max steps reached")
         raise MaxStepsReached(self.max_steps)
+
+    @staticmethod
+    def _fit_tool_context(
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        token_budget: int,
+    ) -> list[dict[str, Any]]:
+        """Fit request-local tool exchanges into the model input budget."""
+        if estimate_request_tokens(messages, tools) <= token_budget:
+            return messages
+
+        fitted = [dict(message) for message in messages]
+        tool_indexes = [i for i, message in enumerate(fitted) if message.get("role") == "tool"]
+
+        # Retain useful head/tail excerpts, shrinking oldest results first.
+        for index in tool_indexes:
+            content = fitted[index].get("content")
+            if not isinstance(content, str) or len(content) <= 1200:
+                continue
+            fitted[index]["content"] = (
+                content[:600] + "\n... [tool result trimmed for context budget] ...\n" + content[-600:]
+            )
+            if estimate_request_tokens(fitted, tools) <= token_budget:
+                return fitted
+
+        # Remove oldest complete tool-call batches, preferring the latest batch.
+        batch_ranges: list[tuple[int, int]] = []
+        index = 0
+        while index < len(fitted):
+            message = fitted[index]
+            if message.get("role") != "assistant" or not message.get("tool_calls"):
+                index += 1
+                continue
+            call_ids = {call.get("id") for call in message["tool_calls"]}
+            end = index + 1
+            seen_ids: set[str | None] = set()
+            while end < len(fitted) and fitted[end].get("role") == "tool":
+                seen_ids.add(fitted[end].get("tool_call_id"))
+                end += 1
+            if call_ids and call_ids <= seen_ids:
+                batch_ranges.append((index, end))
+            index = end
+
+        for start, end in reversed(batch_ranges[:-1]):
+            del fitted[start:end]
+            if estimate_request_tokens(fitted, tools) <= token_budget:
+                return fitted
+
+        # If the newest result alone is too large, reduce all remaining results
+        # to explicit placeholders rather than sending a known-oversized request.
+        for message in fitted:
+            if message.get("role") == "tool" and message.get("content"):
+                message["content"] = "[Tool result omitted: context budget exceeded]"
+        return fitted
 
     def _create_progress_context(self, show_progress: bool):
         """Create progress display context."""

--- a/src/amcp/agent.py
+++ b/src/amcp/agent.py
@@ -106,6 +106,16 @@ class Agent:
 
         # Session-level cumulative tracking
         self.total_llm_calls: int = 0  # Total LLM calls across entire session
+        self.total_input_tokens: int = 0
+        self.total_output_tokens: int = 0
+        self.total_cached_input_tokens: int = 0
+        self.total_cache_write_input_tokens: int = 0
+        self.usage_reported_llm_calls: int = 0
+        self.estimated_input_llm_calls: int = 0
+        self.last_context_tokens: int = 0
+        self.last_context_window: int = 0
+        self.last_output_tokens: int | None = None
+        self.last_usage_from_api: bool = False
 
         # Project rules loader (will be initialized with work_dir during run)
         self._project_rules_loader: ProjectRulesLoader | None = None
@@ -145,6 +155,16 @@ class Agent:
                     self.tool_calls_history = data.get("tool_calls_history", [])
                     self.current_conversation_tool_calls = data.get("current_conversation_tool_calls", [])
                     self.total_llm_calls = data.get("total_llm_calls", 0)
+                    self.total_input_tokens = data.get("total_input_tokens", 0)
+                    self.total_output_tokens = data.get("total_output_tokens", 0)
+                    self.total_cached_input_tokens = data.get("total_cached_input_tokens", 0)
+                    self.total_cache_write_input_tokens = data.get("total_cache_write_input_tokens", 0)
+                    self.usage_reported_llm_calls = data.get("usage_reported_llm_calls", 0)
+                    self.estimated_input_llm_calls = data.get("estimated_input_llm_calls", 0)
+                    self.last_context_tokens = data.get("last_context_tokens", 0)
+                    self.last_context_window = data.get("last_context_window", 0)
+                    self.last_output_tokens = data.get("last_output_tokens")
+                    self.last_usage_from_api = data.get("last_usage_from_api", False)
                     self.console.print(
                         f"[dim]Loaded conversation history: {len(self.conversation_history)} messages, {len(self.tool_calls_history)} total tool calls[/dim]"
                     )
@@ -166,6 +186,16 @@ class Agent:
                 "tool_calls_history": self.tool_calls_history,
                 "current_conversation_tool_calls": self.current_conversation_tool_calls,
                 "total_llm_calls": self.total_llm_calls,
+                "total_input_tokens": self.total_input_tokens,
+                "total_output_tokens": self.total_output_tokens,
+                "total_cached_input_tokens": self.total_cached_input_tokens,
+                "total_cache_write_input_tokens": self.total_cache_write_input_tokens,
+                "usage_reported_llm_calls": self.usage_reported_llm_calls,
+                "estimated_input_llm_calls": self.estimated_input_llm_calls,
+                "last_context_tokens": self.last_context_tokens,
+                "last_context_window": self.last_context_window,
+                "last_output_tokens": self.last_output_tokens,
+                "last_usage_from_api": self.last_usage_from_api,
             }
             with open(self.session_file, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
@@ -178,6 +208,16 @@ class Agent:
         self.tool_calls_history = []
         self.current_conversation_tool_calls = []
         self.total_llm_calls = 0
+        self.total_input_tokens = 0
+        self.total_output_tokens = 0
+        self.total_cached_input_tokens = 0
+        self.total_cache_write_input_tokens = 0
+        self.usage_reported_llm_calls = 0
+        self.estimated_input_llm_calls = 0
+        self.last_context_tokens = 0
+        self.last_context_window = 0
+        self.last_output_tokens = None
+        self.last_usage_from_api = False
         self.current_request_llm_calls = 0
         self.current_request_tool_calls = 0
         try:
@@ -195,6 +235,33 @@ class Agent:
             "total_tool_calls": len(self.tool_calls_history),  # Session total
             "total_llm_calls": self.total_llm_calls,  # Session total
             "session_file": str(self.session_file),
+        }
+
+    def get_token_usage_summary(self) -> dict[str, Any]:
+        """Return current context usage and provider-reported session totals."""
+        context_window = self.last_context_window
+        if not context_window:
+            cfg = load_config()
+            model_config = cfg.chat.model_config if cfg.chat else None
+            context_window = get_model_context_window(
+                self._resolve_model_name(cfg),
+                model_config=model_config,
+            )
+        usage_ratio = self.last_context_tokens / context_window if context_window else 0.0
+        return {
+            "context_tokens": self.last_context_tokens,
+            "context_window": context_window,
+            "context_usage_ratio": usage_ratio,
+            "last_output_tokens": self.last_output_tokens,
+            "last_usage_from_api": self.last_usage_from_api,
+            "total_input_tokens": self.total_input_tokens,
+            "total_output_tokens": self.total_output_tokens,
+            "total_tokens": self.total_input_tokens + self.total_output_tokens,
+            "total_cached_input_tokens": self.total_cached_input_tokens,
+            "total_cache_write_input_tokens": self.total_cache_write_input_tokens,
+            "usage_reported_llm_calls": self.usage_reported_llm_calls,
+            "estimated_input_llm_calls": self.estimated_input_llm_calls,
+            "total_llm_calls": self.total_llm_calls,
         }
 
     @property
@@ -1012,7 +1079,9 @@ class Agent:
                 stream_callback = _stream_callback
 
             messages = self._fit_tool_context(messages, tools, input_token_budget)
+            estimated_input_tokens = estimate_request_tokens(messages, tools)
             resp = llm_client.chat(messages=messages, tools=tools, stream_callback=stream_callback)
+            self._record_llm_usage(resp, estimated_input_tokens, context_window)
 
             if resp.tool_calls:
                 tool_calls = resp.tool_calls
@@ -1040,8 +1109,12 @@ class Agent:
                     )
                     # Get a final response from the LLM with the current messages
                     try:
+                        self.current_request_llm_calls += 1
+                        self.total_llm_calls += 1
                         messages = self._fit_tool_context(messages, [], input_token_budget)
+                        estimated_input_tokens = estimate_request_tokens(messages)
                         final_resp = llm_client.chat(messages=messages)
+                        self._record_llm_usage(final_resp, estimated_input_tokens, context_window)
                         final_text = final_resp.content or ""
                         status.update(f"[bold]Agent {self.name}[/bold] - ✅ Complete")
                         return final_text
@@ -1277,6 +1350,32 @@ class Agent:
         # Max steps reached
         status.update(f"[bold]Agent {self.name}[/bold] - ⚠️ Max steps reached")
         raise MaxStepsReached(self.max_steps)
+
+    def _record_llm_usage(
+        self,
+        response: Any,
+        estimated_input_tokens: int,
+        context_window: int,
+    ) -> None:
+        """Record context occupancy and provider-reported token consumption."""
+        usage = getattr(response, "usage", None)
+        self.last_context_window = context_window
+        if usage is None:
+            self.last_context_tokens = estimated_input_tokens
+            self.last_output_tokens = None
+            self.last_usage_from_api = False
+            self.total_input_tokens += estimated_input_tokens
+            self.estimated_input_llm_calls += 1
+            return
+
+        self.last_context_tokens = usage.prompt_tokens
+        self.last_output_tokens = usage.output_tokens
+        self.last_usage_from_api = True
+        self.total_input_tokens += usage.prompt_tokens
+        self.total_output_tokens += usage.output_tokens
+        self.total_cached_input_tokens += usage.cached_input_tokens
+        self.total_cache_write_input_tokens += usage.cache_write_input_tokens
+        self.usage_reported_llm_calls += 1
 
     @staticmethod
     def _fit_tool_context(

--- a/src/amcp/compaction.py
+++ b/src/amcp/compaction.py
@@ -36,6 +36,7 @@ Example:
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from enum import Enum
@@ -306,6 +307,23 @@ def estimate_tokens(messages: list[dict[str, Any]], use_tiktoken: bool = True) -
                     total += len(str(args)) // 4
 
     return total
+
+
+def estimate_request_tokens(
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None = None,
+    use_tiktoken: bool = True,
+) -> int:
+    """Estimate tokens for a complete model request, including tool schemas."""
+    total = estimate_tokens(messages, use_tiktoken=use_tiktoken)
+    if not tools:
+        return total
+
+    serialized_tools = json.dumps(tools, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return total + estimate_tokens(
+        [{"role": "system", "content": serialized_tools}],
+        use_tiktoken=use_tiktoken,
+    )
 
 
 def _messages_to_text(messages: list[dict[str, Any]]) -> str:

--- a/src/amcp/llm.py
+++ b/src/amcp/llm.py
@@ -30,6 +30,22 @@ def _extract_think_tags(content: str) -> tuple[str | None, str]:
 
 
 @dataclass
+class TokenUsage:
+    """Normalized token usage returned by an LLM provider."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+    cached_input_tokens: int = 0
+    cache_write_input_tokens: int = 0
+
+    @property
+    def prompt_tokens(self) -> int:
+        """Return all tokens occupying the input context."""
+        return self.input_tokens + self.cached_input_tokens + self.cache_write_input_tokens
+
+
+@dataclass
 class LLMResponse:
     """Unified response from LLM."""
 
@@ -37,6 +53,74 @@ class LLMResponse:
     tool_calls: list[ToolCall] | None = None
     stop_reason: str | None = None
     thinking: str | None = None  # Reasoning/thinking content from LLM
+    usage: TokenUsage | None = None
+
+
+def _usage_value(usage: Any, name: str) -> int:
+    """Read an integer usage field from SDK objects or dictionaries."""
+    if usage is None:
+        return 0
+    value = usage.get(name, 0) if isinstance(usage, dict) else getattr(usage, name, 0)
+    return int(value or 0)
+
+
+def _usage_details_value(usage: Any, details_name: str, value_name: str) -> int:
+    """Read a nested usage detail from SDK objects or dictionaries."""
+    if usage is None:
+        return 0
+    details = usage.get(details_name) if isinstance(usage, dict) else getattr(usage, details_name, None)
+    return _usage_value(details, value_name)
+
+
+def _openai_chat_usage(usage: Any) -> TokenUsage | None:
+    """Normalize Chat Completions usage."""
+    if usage is None:
+        return None
+    prompt_tokens = _usage_value(usage, "prompt_tokens")
+    output_tokens = _usage_value(usage, "completion_tokens")
+    cache_read = _usage_details_value(usage, "prompt_tokens_details", "cached_tokens")
+    cache_write = _usage_details_value(usage, "prompt_tokens_details", "cache_write_tokens")
+    input_tokens = max(0, prompt_tokens - cache_read - cache_write)
+    return TokenUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=_usage_value(usage, "total_tokens") or prompt_tokens + output_tokens,
+        cached_input_tokens=cache_read,
+        cache_write_input_tokens=cache_write,
+    )
+
+
+def _responses_usage(usage: Any) -> TokenUsage | None:
+    """Normalize OpenAI Responses API usage."""
+    if usage is None:
+        return None
+    provider_input_tokens = _usage_value(usage, "input_tokens")
+    output_tokens = _usage_value(usage, "output_tokens")
+    cache_read = _usage_details_value(usage, "input_tokens_details", "cached_tokens")
+    input_tokens = max(0, provider_input_tokens - cache_read)
+    return TokenUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=_usage_value(usage, "total_tokens") or provider_input_tokens + output_tokens,
+        cached_input_tokens=cache_read,
+    )
+
+
+def _anthropic_usage(usage: Any) -> TokenUsage | None:
+    """Normalize Anthropic usage, including prompt-cache tokens."""
+    if usage is None:
+        return None
+    uncached_input = _usage_value(usage, "input_tokens")
+    cache_creation = _usage_value(usage, "cache_creation_input_tokens")
+    cache_read = _usage_value(usage, "cache_read_input_tokens")
+    output_tokens = _usage_value(usage, "output_tokens")
+    return TokenUsage(
+        input_tokens=uncached_input,
+        output_tokens=output_tokens,
+        total_tokens=uncached_input + cache_creation + cache_read + output_tokens,
+        cached_input_tokens=cache_read,
+        cache_write_input_tokens=cache_creation,
+    )
 
 
 class BaseLLMClient(ABC):
@@ -95,10 +179,13 @@ class OpenAIClient(BaseLLMClient):
             accumulated_content = []
             tool_calls_chunks = {}  # index -> accumulated chunk
             finish_reason = None
+            usage = None
 
             response = self.client.chat.completions.create(**params)
 
             for chunk in response:
+                if getattr(chunk, "usage", None) is not None:
+                    usage = _openai_chat_usage(chunk.usage)
                 # Some APIs (e.g., DeepSeek) may return chunks with empty choices
                 if not chunk.choices:
                     continue
@@ -149,6 +236,7 @@ class OpenAIClient(BaseLLMClient):
                 tool_calls=tool_calls if tool_calls else None,
                 stop_reason=finish_reason,
                 thinking=thinking,
+                usage=usage,
             )
 
         else:
@@ -174,7 +262,11 @@ class OpenAIClient(BaseLLMClient):
                 thinking, content = _extract_think_tags(content)
 
             return LLMResponse(
-                content=content, tool_calls=tool_calls, stop_reason=resp.choices[0].finish_reason, thinking=thinking
+                content=content,
+                tool_calls=tool_calls,
+                stop_reason=resp.choices[0].finish_reason,
+                thinking=thinking,
+                usage=_openai_chat_usage(getattr(resp, "usage", None)),
             )
 
 
@@ -233,6 +325,7 @@ class OpenAIResponsesClient(BaseLLMClient):
             content="\n".join(content_parts) if content_parts else None,
             tool_calls=tool_calls if tool_calls else None,
             stop_reason=resp.stop_reason,
+            usage=_responses_usage(getattr(resp, "usage", None)),
         )
 
 
@@ -335,6 +428,7 @@ class AnthropicClient(BaseLLMClient):
             tool_calls=tool_calls if tool_calls else None,
             stop_reason=resp.stop_reason,
             thinking="\n".join(thinking_parts) if thinking_parts else None,
+            usage=_anthropic_usage(getattr(resp, "usage", None)),
         )
 
 

--- a/src/amcp/telegram/handlers.py
+++ b/src/amcp/telegram/handlers.py
@@ -577,17 +577,64 @@ class TelegramHandlers:
         queued = len(current_session.queue) if current_session else 0
         active = bool(current_session and current_session.current_task and not current_session.current_task.done())
         policy = self._describe_chat_policy(update.message)
+        lines = [
+            f"Sessions: {len(sessions)}",
+            f"Current session: {current or 'none'}",
+            f"Active task: {active}",
+            f"Queued: {queued}",
+            f"Policy: {policy}",
+        ]
+        usage_getter = getattr(current_session.agent, "get_token_usage_summary", None) if current_session else None
+        if usage_getter:
+            usage = usage_getter()
+            if usage["last_usage_from_api"]:
+                source = "API"
+            elif usage["context_tokens"]:
+                source = "estimated"
+            else:
+                source = "no usage yet"
+            lines.extend(
+                [
+                    (
+                        f"Context: {usage['context_tokens']:,} / {usage['context_window']:,} "
+                        f"({usage['context_usage_ratio']:.1%}, {source})"
+                    ),
+                    (
+                        f"Last output: {usage['last_output_tokens']:,} tokens"
+                        if usage["last_output_tokens"] is not None
+                        else "Last output: unavailable"
+                    ),
+                ]
+            )
+            estimated_calls = usage["estimated_input_llm_calls"]
+            if estimated_calls:
+                lines.extend(
+                    [
+                        (
+                            f"Chat-loop input: {usage['total_input_tokens']:,} tokens "
+                            f"({estimated_calls} call(s) estimated)"
+                        ),
+                        f"Chat-loop output: {usage['total_output_tokens']:,} tokens (partial, API only)",
+                    ]
+                )
+            else:
+                lines.append(
+                    f"Chat-loop tokens: {usage['total_input_tokens']:,} input + "
+                    f"{usage['total_output_tokens']:,} output = {usage['total_tokens']:,}"
+                )
+            cache_read = usage["total_cached_input_tokens"]
+            cache_write = usage["total_cache_write_input_tokens"]
+            if cache_read or cache_write:
+                prompt_tokens = usage["total_input_tokens"]
+                hit_rate = cache_read / prompt_tokens if prompt_tokens else 0.0
+                lines.append(f"Cache: {hit_rate:.1%} hit · {cache_read:,} read, {cache_write:,} write")
+            if usage["usage_reported_llm_calls"] < usage["total_llm_calls"]:
+                lines.append(
+                    f"API usage reported: {usage['usage_reported_llm_calls']} / {usage['total_llm_calls']} LLM calls"
+                )
         await self._bot.send_text(
             chat_id,
-            "\n".join(
-                [
-                    f"Sessions: {len(sessions)}",
-                    f"Current session: {current or 'none'}",
-                    f"Active task: {active}",
-                    f"Queued: {queued}",
-                    f"Policy: {policy}",
-                ]
-            ),
+            "\n".join(lines),
         )
 
     async def handle_session(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -251,6 +251,46 @@ class TestAgentHistoryManagement:
                 assert data["conversation_history"] == [{"role": "user", "content": "hi"}]
 
 
+class TestAgentContextBudget:
+    def test_fit_tool_context_trims_old_result_without_mutating_input(self):
+        old_content = "old result " * 3000
+        latest_content = "latest result " * 1000
+        messages = [
+            {"role": "system", "content": "system"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "old",
+                        "type": "function",
+                        "function": {"name": "web_fetch", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "old", "content": old_content},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "latest",
+                        "type": "function",
+                        "function": {"name": "web_fetch", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "latest", "content": latest_content},
+        ]
+        budget = 5000
+
+        fitted = Agent._fit_tool_context(messages, [], budget)
+
+        assert "trimmed for context budget" in fitted[2]["content"]
+        assert fitted[4]["content"] == latest_content
+        assert messages[2]["content"] == old_content
+
+
 class TestAgentEventCallbacks:
     def test_add_and_emit_event(self, tmp_path):
         with patch("amcp.agent.Path.home") as mock_home:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -12,6 +12,7 @@ from amcp.agent import Agent, AgentExecutionError, BusyError, MaxStepsReached
 from amcp.agent_spec import ResolvedAgentSpec
 from amcp.config import AMCPConfig, ChatConfig, ContextConfig
 from amcp.hooks import HookOutput
+from amcp.llm import LLMResponse, TokenUsage
 from amcp.memory import MemoryManager, MemoryStore
 from amcp.multi_agent import AgentMode
 
@@ -289,6 +290,53 @@ class TestAgentContextBudget:
         assert "trimmed for context budget" in fitted[2]["content"]
         assert fitted[4]["content"] == latest_content
         assert messages[2]["content"] == old_content
+
+    def test_records_provider_usage_for_status(self, tmp_path):
+        with patch("amcp.agent.Path.home") as mock_home, patch("amcp.agent.load_config") as mock_load:
+            mock_home.return_value = tmp_path
+            mock_load.return_value = MagicMock()
+            agent = Agent(session_id="test-session")
+
+        response = LLMResponse(
+            content="done",
+            usage=TokenUsage(
+                input_tokens=10_000,
+                output_tokens=500,
+                total_tokens=12_500,
+                cached_input_tokens=2_000,
+            ),
+        )
+        agent.total_llm_calls = 1
+
+        agent._record_llm_usage(response, estimated_input_tokens=10_000, context_window=64_000)
+
+        usage = agent.get_token_usage_summary()
+        assert usage["context_tokens"] == 12_000
+        assert usage["context_usage_ratio"] == 0.1875
+        assert usage["total_tokens"] == 12_500
+        assert usage["total_cached_input_tokens"] == 2_000
+        assert usage["total_cache_write_input_tokens"] == 0
+        assert usage["last_usage_from_api"] is True
+
+    def test_estimates_input_when_provider_omits_usage(self, tmp_path):
+        with patch("amcp.agent.Path.home") as mock_home, patch("amcp.agent.load_config") as mock_load:
+            mock_home.return_value = tmp_path
+            mock_load.return_value = MagicMock()
+            agent = Agent(session_id="test-session")
+
+        agent.total_llm_calls = 1
+        agent._record_llm_usage(
+            LLMResponse(content="done"),
+            estimated_input_tokens=8_000,
+            context_window=64_000,
+        )
+
+        usage = agent.get_token_usage_summary()
+        assert usage["context_tokens"] == 8_000
+        assert usage["total_input_tokens"] == 8_000
+        assert usage["last_output_tokens"] is None
+        assert usage["estimated_input_llm_calls"] == 1
+        assert usage["last_usage_from_api"] is False
 
 
 class TestAgentEventCallbacks:

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -9,6 +9,7 @@ from amcp.compaction import (
     CompactionResult,
     CompactionStrategy,
     SmartCompactor,
+    estimate_request_tokens,
     estimate_tokens,
     get_model_context_window,
 )
@@ -235,6 +236,22 @@ class TestSmartCompactor:
         # Create content that's ~500 tokens
         messages = [{"role": "user", "content": "x" * 2000}]
         assert compactor.should_compact(messages) is False
+
+    def test_request_estimate_includes_tool_schemas(self):
+        """Complete request estimates include tool definitions sent to the provider."""
+        messages = [{"role": "user", "content": "Read this page"}]
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_fetch",
+                    "description": "Fetch a web page " * 100,
+                    "parameters": {"type": "object", "properties": {"url": {"type": "string"}}},
+                },
+            }
+        ]
+
+        assert estimate_request_tokens(messages, tools) > estimate_tokens(messages)
 
     def test_get_token_usage(self, mock_client):
         """Test get_token_usage returns correct structure."""

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,5 +1,7 @@
 """Tests for LLM client abstraction."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from amcp.config import ChatConfig
@@ -59,11 +61,58 @@ class TestOpenAIClient:
         client = OpenAIClient(base_url="https://api.openai.com/v1", api_key="test-key", model="gpt-4o")
         assert client.model == "gpt-4o"
 
+    def test_chat_captures_provider_usage(self):
+        client = OpenAIClient(base_url="https://api.openai.com/v1", api_key="test-key", model="gpt-4o")
+        client.client.chat.completions.create = lambda **_kwargs: SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="done", tool_calls=None),
+                    finish_reason="stop",
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=120,
+                completion_tokens=30,
+                total_tokens=150,
+                prompt_tokens_details=SimpleNamespace(cached_tokens=40),
+            ),
+        )
+
+        response = client.chat([{"role": "user", "content": "hello"}])
+
+        assert response.usage is not None
+        assert response.usage.input_tokens == 80
+        assert response.usage.prompt_tokens == 120
+        assert response.usage.output_tokens == 30
+        assert response.usage.total_tokens == 150
+        assert response.usage.cached_input_tokens == 40
+
 
 class TestOpenAIResponsesClient:
     def test_client_creation(self):
         client = OpenAIResponsesClient(base_url="https://api.openai.com/v1", api_key="test-key", model="gpt-4o")
         assert client.model == "gpt-4o"
+
+    def test_responses_captures_provider_usage(self):
+        client = OpenAIResponsesClient(base_url="https://api.openai.com/v1", api_key="test-key", model="gpt-4o")
+        client.client.responses.create = lambda **_kwargs: SimpleNamespace(
+            output=[],
+            stop_reason="stop",
+            usage=SimpleNamespace(
+                input_tokens=200,
+                output_tokens=50,
+                total_tokens=250,
+                input_tokens_details=SimpleNamespace(cached_tokens=80),
+            ),
+        )
+
+        response = client.chat([{"role": "user", "content": "hello"}])
+
+        assert response.usage is not None
+        assert response.usage.input_tokens == 120
+        assert response.usage.prompt_tokens == 200
+        assert response.usage.output_tokens == 50
+        assert response.usage.cached_input_tokens == 80
 
 
 class TestAnthropicClient:
@@ -73,3 +122,30 @@ class TestAnthropicClient:
             assert client.model == "claude-sonnet-4-20250514"
         except ImportError:
             pytest.skip("anthropic package not installed")
+
+    def test_anthropic_captures_provider_usage(self):
+        client = AnthropicClient.__new__(AnthropicClient)
+        client.model = "claude-sonnet-4-20250514"
+        client.client = SimpleNamespace(
+            messages=SimpleNamespace(
+                create=lambda **_kwargs: SimpleNamespace(
+                    content=[],
+                    stop_reason="end_turn",
+                    usage=SimpleNamespace(
+                        input_tokens=100,
+                        output_tokens=20,
+                        cache_creation_input_tokens=10,
+                        cache_read_input_tokens=30,
+                    ),
+                )
+            )
+        )
+
+        response = client.chat([{"role": "user", "content": "hello"}])
+
+        assert response.usage is not None
+        assert response.usage.input_tokens == 100
+        assert response.usage.prompt_tokens == 140
+        assert response.usage.output_tokens == 20
+        assert response.usage.cached_input_tokens == 30
+        assert response.usage.cache_write_input_tokens == 10

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -182,6 +182,43 @@ def test_handle_models_lists_configured_providers():
     asyncio.run(_run())
 
 
+def test_handle_status_shows_context_and_token_usage():
+    async def _run():
+        handlers, fake_bot = _make_handlers(TelegramConfig(), allowed_users={42})
+        message = _make_message(text="/status", user_id=42)
+        update = SimpleNamespace(
+            effective_chat=message.chat,
+            effective_user=message.from_user,
+            message=message,
+        )
+        session = handlers._session_manager.create_session(123)
+        session.agent.get_token_usage_summary = lambda: {
+            "context_tokens": 16_000,
+            "context_window": 64_000,
+            "context_usage_ratio": 0.25,
+            "last_output_tokens": 500,
+            "last_usage_from_api": True,
+            "total_input_tokens": 30_000,
+            "total_output_tokens": 2_000,
+            "total_tokens": 32_000,
+            "total_cached_input_tokens": 4_000,
+            "total_cache_write_input_tokens": 1_000,
+            "usage_reported_llm_calls": 3,
+            "estimated_input_llm_calls": 0,
+            "total_llm_calls": 3,
+        }
+
+        await handlers.handle_status(update, SimpleNamespace(args=[]))
+
+        status = fake_bot.sent_texts[-1][1]
+        assert "Context: 16,000 / 64,000 (25.0%, API)" in status
+        assert "Last output: 500 tokens" in status
+        assert "Chat-loop tokens: 30,000 input + 2,000 output = 32,000" in status
+        assert "Cache: 13.3% hit · 4,000 read, 1,000 write" in status
+
+    asyncio.run(_run())
+
+
 def test_handle_model_use_switches_provider_for_admin():
     async def _run():
         handlers, fake_bot = _make_handlers(TelegramConfig(), allowed_users={42}, admin_users={42})


### PR DESCRIPTION
# Pull Request

## Description

Prevent oversized LLM requests when long web/tool results accumulate, and expose context/token usage in Telegram `/status`.

- estimate the complete request payload, including the system prompt and tool schemas, before compaction
- enforce the context budget before every tool-loop LLM call while preserving the newest tool results where possible
- normalize OpenAI Chat Completions, OpenAI Responses, and Anthropic token/cache usage
- persist per-session usage totals and fall back to estimated input tokens when a provider omits usage
- show latest context-window occupancy, output tokens, chat-loop totals, and cache read/write statistics in Telegram `/status`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Testing

```bash
ruff format src tests
ruff check src tests
python -m pytest -q
```

Result: 753 tests passed.

## Related Issues

None.
