### PR TITLE
fix: persist Telegram memories across sessions

### DIFF
--- a/src/amcp/agent.py
+++ b/src/amcp/agent.py
@@ -50,6 +50,9 @@ from .ui import LiveUI
 logger = logging.getLogger(__name__)
 
 DEFAULT_BASH_TOOL_LIMIT = 100
+MEMORY_REVIEW_TURN_INTERVAL = 10
+MEMORY_LOG_USER_LIMIT = 1000
+MEMORY_LOG_AGENT_LIMIT = 2000
 
 
 class AgentExecutionError(Exception):
@@ -116,6 +119,7 @@ class Agent:
         self.last_context_window: int = 0
         self.last_output_tokens: int | None = None
         self.last_usage_from_api: bool = False
+        self._last_memory_review_turn_count: int = 0
 
         # Project rules loader (will be initialized with work_dir during run)
         self._project_rules_loader: ProjectRulesLoader | None = None
@@ -165,6 +169,7 @@ class Agent:
                     self.last_context_window = data.get("last_context_window", 0)
                     self.last_output_tokens = data.get("last_output_tokens")
                     self.last_usage_from_api = data.get("last_usage_from_api", False)
+                    self._last_memory_review_turn_count = data.get("last_memory_review_turn_count", 0)
                     self.console.print(
                         f"[dim]Loaded conversation history: {len(self.conversation_history)} messages, {len(self.tool_calls_history)} total tool calls[/dim]"
                     )
@@ -196,6 +201,7 @@ class Agent:
                 "last_context_window": self.last_context_window,
                 "last_output_tokens": self.last_output_tokens,
                 "last_usage_from_api": self.last_usage_from_api,
+                "last_memory_review_turn_count": self._last_memory_review_turn_count,
             }
             with open(self.session_file, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
@@ -218,6 +224,7 @@ class Agent:
         self.last_context_window = 0
         self.last_output_tokens = None
         self.last_usage_from_api = False
+        self._last_memory_review_turn_count = 0
         self.current_request_llm_calls = 0
         self.current_request_tool_calls = 0
         try:
@@ -225,6 +232,38 @@ class Agent:
                 self.session_file.unlink()
         except OSError as e:
             self.console.print(f"[yellow]Warning: Could not delete session file: {e}[/yellow]")
+
+    def _resolve_memory_project_root(self, work_dir: Path | None = None) -> Path:
+        """Return the project root used for project-scoped persistent memory."""
+        configured_root = self.execution_context.get("memory_project_root")
+        if configured_root:
+            return Path(configured_root).expanduser().resolve()
+        return work_dir.resolve() if work_dir else Path.cwd()
+
+    def _memory_history_scope(self, work_dir: Path | None = None) -> str:
+        """Return the default scope for automatic conversation history entries."""
+        if self.execution_context.get("memory_project_root"):
+            return "project"
+        return "project" if work_dir else "user"
+
+    @staticmethod
+    def _conversation_turn_count(messages: list[dict[str, Any]]) -> int:
+        """Count user turns in a conversation snapshot."""
+        return sum(1 for msg in messages if msg.get("role") == "user")
+
+    @staticmethod
+    def _trim_memory_log_text(text: str, limit: int) -> str:
+        """Trim text for compact, readable memory history logs."""
+        stripped = text.strip()
+        if len(stripped) <= limit:
+            return stripped
+        return stripped[:limit].rstrip() + "\n[... truncated ...]"
+
+    def _format_conversation_history_entry(self, user_input: str, result: str) -> str:
+        """Format an automatic conversation history entry."""
+        user = self._trim_memory_log_text(user_input, MEMORY_LOG_USER_LIMIT)
+        agent = self._trim_memory_log_text(result, MEMORY_LOG_AGENT_LIMIT)
+        return f"User:\n{user}\n\nAgent:\n{agent}"
 
     def get_conversation_summary(self) -> dict[str, Any]:
         """Get summary of the conversation (session-level statistics)."""
@@ -415,7 +454,7 @@ class Agent:
             skills_content = skill_manager.get_active_skills_content()
 
         # Get persona and memory context
-        memory_manager = get_memory_manager(resolved_work_dir)
+        memory_manager = get_memory_manager(self._resolve_memory_project_root(work_dir))
         persona_context = memory_manager.get_persona_context()
         memory_context = memory_manager.get_memory_context()
 
@@ -730,6 +769,7 @@ class Agent:
                         work_dir=work_dir,
                         status=status,
                     )
+                    self._last_memory_review_turn_count = self._conversation_turn_count(history_to_add)
 
                     status.update(f"[bold]Agent {self.name}[/bold] compacting context...")
                     history_to_add, _ = compactor.compact(history_to_add)
@@ -755,16 +795,23 @@ class Agent:
 
                 # Log to memory history
                 try:
-                    memory_mgr = get_memory_manager(work_dir)
-                    summary = f"User: {user_input[:200]}\nAgent: {result[:300]}"
+                    memory_mgr = get_memory_manager(self._resolve_memory_project_root(work_dir))
+                    summary = self._format_conversation_history_entry(user_input, result)
                     memory_mgr.append_history(
                         content=summary,
                         session_id=self.session_id,
                         tags=["conversation"],
-                        scope="project" if work_dir else "user",
+                        scope=self._memory_history_scope(work_dir),
                     )
                 except (OSError, ValueError):
                     pass  # Memory logging is best-effort
+
+                await self._maybe_run_periodic_memory_review(
+                    conversation_snapshot=list(self.conversation_history),
+                    system_prompt=system_prompt,
+                    work_dir=work_dir,
+                    status=status,
+                )
 
                 return result
 
@@ -787,7 +834,7 @@ class Agent:
         system_prompt: str,
         work_dir: Path | None,
         status: Any = None,
-    ) -> None:
+    ) -> bool:
         """Run a pre-compaction memory flush to save durable memories.
 
         Inspired by openclaw's pre-compaction memory flush: before the
@@ -808,10 +855,11 @@ class Agent:
             registry = get_tool_registry()
             memory_tool = registry.get_tool("memory")
             if not memory_tool:
-                return
+                return False
             memory_tools = [memory_tool.get_spec()]
 
             self._emit_event("memory.review_start", {})
+            memory_project_root = self._resolve_memory_project_root(work_dir)
 
             result = await run_memory_review(
                 client=client,
@@ -820,21 +868,66 @@ class Agent:
                 conversation_snapshot=conversation_snapshot,
                 tools=memory_tools,
                 tool_registry=registry,
-                project_root=str(work_dir) if work_dir else None,
+                project_root=str(memory_project_root),
             )
 
+            saved = bool(result and result.strip() != "Nothing to save.")
             self._emit_event(
                 "memory.review_complete",
-                {"saved": result != "Nothing to save." if result else False},
+                {"saved": saved},
             )
 
-            if result and result.strip() != "Nothing to save.":
-                self.console.print("[dim]Memory flush: saved durable memories before compaction[/dim]")
+            if saved:
+                self.console.print("[dim]Memory flush: saved durable memories[/dim]")
             else:
                 logger.debug("Memory flush: nothing to save")
+            return saved
 
         except Exception as e:
             logger.debug(f"Memory flush failed (non-critical): {e}")
+            return False
+
+    async def flush_memory(
+        self,
+        work_dir: Path | None = None,
+        *,
+        conversation_snapshot: list[dict[str, Any]] | None = None,
+        status: Any = None,
+    ) -> bool:
+        """Review the current conversation and persist durable memories."""
+        snapshot = list(conversation_snapshot or self.conversation_history)
+        if not snapshot:
+            return False
+        system_prompt = self._get_system_prompt(work_dir)
+        saved = await self._run_memory_review(
+            conversation_snapshot=snapshot,
+            system_prompt=system_prompt,
+            work_dir=work_dir,
+            status=status,
+        )
+        self._last_memory_review_turn_count = self._conversation_turn_count(snapshot)
+        self._save_conversation_history()
+        return saved
+
+    async def _maybe_run_periodic_memory_review(
+        self,
+        conversation_snapshot: list[dict[str, Any]],
+        system_prompt: str,
+        work_dir: Path | None,
+        status: Any = None,
+    ) -> None:
+        """Run a lightweight memory review every N user turns."""
+        turn_count = self._conversation_turn_count(conversation_snapshot)
+        if turn_count - self._last_memory_review_turn_count < MEMORY_REVIEW_TURN_INTERVAL:
+            return
+        await self._run_memory_review(
+            conversation_snapshot=conversation_snapshot,
+            system_prompt=system_prompt,
+            work_dir=work_dir,
+            status=status,
+        )
+        self._last_memory_review_turn_count = turn_count
+        self._save_conversation_history()
 
     def is_busy(self) -> bool:
         """Check if this agent's session is currently busy."""
@@ -1243,8 +1336,11 @@ class Agent:
 
                                 registry = get_tool_registry()
                                 exec_args = args
-                                if tool_name == "memory" and work_dir is not None:
-                                    exec_args = {**args, "project_root": str(work_dir)}
+                                if tool_name == "memory":
+                                    exec_args = {
+                                        **args,
+                                        "project_root": str(self._resolve_memory_project_root(work_dir)),
+                                    }
                                 tool_result = registry.execute_tool(tool_name, **exec_args)
 
                                 if tool_result.success:

--- a/src/amcp/memory_review.py
+++ b/src/amcp/memory_review.py
@@ -7,11 +7,10 @@ Two-layer memory strategy:
    normal conversation — user preferences → upsert_fact, personality →
    write_soul, identity → identify, etc.
 
-2. **Pre-compaction memory flush** (on-demand): when the conversation is
-   about to be compacted (context too large), run a focused LLM call with
-   only the memory tool available, asking the agent to save durable
-   memories before they get summarized away. Inspired by openclaw's
-   pre-compaction flush; lighter than hermes-agent's every-N-turns nudge.
+2. **Memory review flush** (on-demand): when the conversation reaches a
+   durability checkpoint (compaction, periodic review, or session rollover),
+   run a focused LLM call with only the memory tool available, asking the
+   agent to save durable memories before context is compacted or abandoned.
 """
 
 from __future__ import annotations
@@ -63,8 +62,9 @@ loaded automatically in every new session.
 
 
 MEMORY_REVIEW_PROMPT = """\
-The conversation is about to be compacted (summarized to save context). \
-Before that happens, save any durable memories that would be lost.
+The conversation has reached a memory review checkpoint (compaction, periodic \
+review, or session rollover). Save any durable memories that would otherwise \
+be hard to recover later.
 
 Focus on:
 1. Has the user revealed things about themselves — their persona, desires, \

--- a/src/amcp/telegram/bot.py
+++ b/src/amcp/telegram/bot.py
@@ -15,7 +15,7 @@ from ..agent import Agent, BusyError, create_agent_by_name
 from ..agent_spec import get_default_agent_spec
 from ..config import load_config, save_config
 from ..event_bus import EventType, get_event_bus
-from ..memory import get_memory_manager
+from ..memory import CONFIG_DIR, get_memory_manager
 from ..multi_agent import get_agent_registry
 from .auth import AuthMiddleware
 from .config import TelegramConfig, normalize_dm_policy, normalize_group_policy
@@ -36,6 +36,9 @@ except ImportError:  # pragma: no cover - optional dependency
     filters = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
+
+TELEGRAM_MEMORY_LOG_USER_LIMIT = 1000
+TELEGRAM_MEMORY_LOG_AGENT_LIMIT = 2000
 
 
 @dataclass
@@ -302,6 +305,32 @@ class TelegramBot:
         session.queue.clear()
         return cancelled, queued
 
+    def memory_project_root(self, chat_id: int) -> Path:
+        """Return the isolated project-memory root for a Telegram chat."""
+        return CONFIG_DIR / "telegram" / f"chat_{chat_id}"
+
+    def _bind_session_memory(self, chat_id: int, session: Any) -> None:
+        context = getattr(session.agent, "execution_context", None)
+        if isinstance(context, dict):
+            context["memory_project_root"] = str(self.memory_project_root(chat_id))
+
+    async def flush_session_memory(self, chat_id: int, session: Any) -> bool:
+        """Flush durable memory for a Telegram session before it is replaced."""
+        self._bind_session_memory(chat_id, session)
+        flush = getattr(session.agent, "flush_memory", None)
+        if not callable(flush):
+            return False
+        try:
+            return bool(
+                await asyncio.wait_for(
+                    flush(work_dir=self._work_dir),
+                    timeout=60,
+                )
+            )
+        except Exception:
+            logger.exception("Telegram memory flush failed.")
+            return False
+
     def create_pairing_request(self, user_id: int, chat_id: int, username: str | None = None) -> tuple[str, bool]:
         self._prune_pairing_requests()
         for request in self._pairing_requests.values():
@@ -435,6 +464,7 @@ class TelegramBot:
     async def _process_message(self, session: Any, message: TelegramQueuedMessage) -> None:
         generation = getattr(session, "generation", 0)
         task: asyncio.Task | None = None
+        self._bind_session_memory(message.chat_id, session)
         async with self._typing_session(message.chat_id):
             try:
                 task = asyncio.create_task(
@@ -481,13 +511,25 @@ class TelegramBot:
 
         if getattr(session, "generation", 0) != generation:
             return
-        memory_manager = get_memory_manager(self._work_dir)
+        memory_manager = get_memory_manager(self.memory_project_root(message.chat_id))
         memory_manager.append_history(
-            content=(f"[Telegram] User {message.user_id}: {message.text[:200]}\nAgent: {response_text[:300]}"),
+            content=self._format_telegram_history_entry(message, response_text),
             session_id=session.session_id,
             tags=["telegram", "conversation"],
             scope="project",
         )
+
+    @staticmethod
+    def _trim_memory_log_text(text: str, limit: int) -> str:
+        stripped = text.strip()
+        if len(stripped) <= limit:
+            return stripped
+        return stripped[:limit].rstrip() + "\n[... truncated ...]"
+
+    def _format_telegram_history_entry(self, message: TelegramQueuedMessage, response_text: str) -> str:
+        user = self._trim_memory_log_text(message.text, TELEGRAM_MEMORY_LOG_USER_LIMIT)
+        agent = self._trim_memory_log_text(response_text, TELEGRAM_MEMORY_LOG_AGENT_LIMIT)
+        return f"[Telegram] chat={message.chat_id} user={message.user_id}\n\nUser:\n{user}\n\nAgent:\n{agent}"
 
     def _build_application(self) -> Application:
         application = ApplicationBuilder().token(self._token).post_init(self._post_init).build()

--- a/src/amcp/telegram/handlers.py
+++ b/src/amcp/telegram/handlers.py
@@ -724,7 +724,13 @@ class TelegramHandlers:
             return
 
         if result.action == "new_session":
-            session = self._session_manager.create_session(chat_id, abandon_current=True)
+            old_session = self._session_manager.get_current_session(chat_id)
+            if old_session:
+                self._session_manager.abandon_current_session(chat_id)
+                flush_session_memory = getattr(self._bot, "flush_session_memory", None)
+                if callable(flush_session_memory):
+                    await flush_session_memory(chat_id, old_session)
+            session = self._session_manager.create_session(chat_id)
             await self._bot.send_text(chat_id, f"Created session: {session.session_id}")
             return
 
@@ -781,7 +787,8 @@ class TelegramHandlers:
             await self._bot.send_text(update.effective_chat.id, "Usage: /memory search <query>")
             return
         query = " ".join(args[1:])
-        memory_manager = get_memory_manager(self._work_dir)
+        memory_project_root = getattr(self._bot, "memory_project_root", lambda _chat_id: self._work_dir)
+        memory_manager = get_memory_manager(memory_project_root(update.effective_chat.id))
         results = memory_manager.search(query)
         if not results:
             await self._bot.send_text(update.effective_chat.id, "No results found.")

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -238,6 +238,54 @@ class TestAgentHistoryManagement:
                 assert summary["message_count"] == 1
                 assert summary["total_tool_calls"] == 1
                 assert summary["total_llm_calls"] == 3
+
+    @pytest.mark.asyncio
+    async def test_periodic_memory_review_runs_every_ten_user_turns(self, tmp_path):
+        with patch("amcp.agent.Path.home") as mock_home, patch("amcp.agent.load_config") as mock_load:
+            mock_home.return_value = tmp_path
+            mock_load.return_value = MagicMock()
+            agent = Agent(session_id="test-session")
+
+        conversation = []
+        for idx in range(10):
+            conversation.extend(
+                [
+                    {"role": "user", "content": f"u{idx}"},
+                    {"role": "assistant", "content": f"a{idx}"},
+                ]
+            )
+
+        with patch.object(agent, "_run_memory_review", new_callable=AsyncMock) as review:
+            await agent._maybe_run_periodic_memory_review(
+                conversation_snapshot=conversation,
+                system_prompt="system",
+                work_dir=tmp_path,
+                status=MagicMock(),
+            )
+
+        review.assert_awaited_once()
+        assert agent._last_memory_review_turn_count == 10
+
+    @pytest.mark.asyncio
+    async def test_flush_memory_marks_reviewed_turn_count(self, tmp_path):
+        with patch("amcp.agent.Path.home") as mock_home, patch("amcp.agent.load_config") as mock_load:
+            mock_home.return_value = tmp_path
+            mock_load.return_value = MagicMock()
+            agent = Agent(session_id="test-session")
+        agent.conversation_history = [
+            {"role": "user", "content": "remember I prefer concise replies"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+        with (
+            patch.object(agent, "_get_system_prompt", return_value="system"),
+            patch.object(agent, "_run_memory_review", new_callable=AsyncMock, return_value=True) as review,
+        ):
+            saved = await agent.flush_memory(work_dir=tmp_path)
+
+        assert saved is True
+        review.assert_awaited_once()
+        assert agent._last_memory_review_turn_count == 1
 
     def test_save_conversation_history(self, tmp_path):
         with patch("amcp.agent.Path.home") as mock_home:

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -20,6 +20,12 @@ from amcp.telegram.handlers import (
 class _FakeAgent:
     def __init__(self, session_id: str) -> None:
         self.session_id = session_id
+        self.execution_context: dict[str, str] = {}
+        self.flush_calls: list[dict] = []
+
+    async def flush_memory(self, **kwargs):
+        self.flush_calls.append(kwargs)
+        return True
 
 
 class _FakeBot:
@@ -29,6 +35,7 @@ class _FakeBot:
         self.sent_texts: list[tuple[int, str]] = []
         self.prompts: list[tuple[int, int, str]] = []
         self.model_provider_requests: list[str] = []
+        self.flushed_sessions: list[tuple[int, str]] = []
 
     def create_pairing_request(self, user_id: int, chat_id: int, username: str | None = None):
         self.pairing_requests.append((user_id, chat_id, username))
@@ -42,6 +49,10 @@ class _FakeBot:
 
     def cancel_session(self, chat_id: int):
         return False, False
+
+    async def flush_session_memory(self, chat_id: int, session):
+        self.flushed_sessions.append((chat_id, session.session_id))
+        return await session.agent.flush_memory()
 
     def models_summary(self) -> str:
         return "Configured providers:\n* test"
@@ -143,6 +154,30 @@ def test_handle_new_uses_shared_session_command():
 
         assert fake_bot.sent_texts
         assert fake_bot.sent_texts[-1][1].startswith("Created session: telegram-123-")
+
+    asyncio.run(_run())
+
+
+def test_handle_new_flushes_old_session_before_replacement():
+    async def _run():
+        handlers, fake_bot = _make_handlers(TelegramConfig(), allowed_users={42})
+        old_session = handlers._session_manager.create_session(123)
+        old_session.queue.append(TelegramQueuedMessage(chat_id=123, user_id=42, text="queued"))
+        message = _make_message(text="/new", user_id=42)
+        update = SimpleNamespace(
+            effective_chat=message.chat,
+            effective_user=message.from_user,
+            message=message,
+        )
+
+        await handlers.handle_new(update, SimpleNamespace(args=[]))
+
+        new_session_id = handlers._session_manager.get_current_session_id(123)
+        assert new_session_id != old_session.session_id
+        assert old_session.generation == 1
+        assert len(old_session.queue) == 0
+        assert fake_bot.flushed_sessions == [(123, old_session.session_id)]
+        assert old_session.agent.flush_calls == [{}]
 
     asyncio.run(_run())
 


### PR DESCRIPTION
# Pull Request

## Description
Persist useful Telegram context across `/new` session resets by flushing durable memories before replacing the old session, adding periodic memory reviews, isolating Telegram project memory per chat, and writing richer history entries.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that the feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Testing

```bash
python -m ruff format --check src tests
python -m ruff check src tests
python -m pytest -q
```

## Related Issues
None.
