### PR TITLE
fix: align server and telegram session queues

### DIFF
--- a/src/amcp/server/routes/sessions.py
+++ b/src/amcp/server/routes/sessions.py
@@ -36,6 +36,36 @@ async def _safe_emit(coro: Coroutine[Any, Any, None]) -> None:
         await coro
 
 
+def _queue_priority(priority: str):
+    """Map server API priority strings to the agent queue enum."""
+    from ...message_queue import MessagePriority as QueuePriority
+
+    priority_map = {
+        "low": QueuePriority.LOW,
+        "normal": QueuePriority.NORMAL,
+        "high": QueuePriority.HIGH,
+        "urgent": QueuePriority.URGENT,
+    }
+    return priority_map.get(priority, QueuePriority.NORMAL)
+
+
+async def _enqueue_agent_prompt(session: Any, content: str, request: PromptRequest) -> int:
+    """Enqueue a prompt directly into the agent session queue and return its position."""
+    from ...message_queue import get_message_queue_manager
+
+    position = session.agent.queued_count() + 1
+    queue_manager = get_message_queue_manager()
+    await queue_manager.enqueue(
+        session_id=session.agent.session_id,
+        prompt=content,
+        priority=_queue_priority(request.priority.value),
+        work_dir=session.cwd,
+        stream=request.stream,
+        show_progress=False,
+    )
+    return position
+
+
 @router.post("", response_model=Session)
 async def create_session(request: CreateSessionRequest | None = None) -> Session:
     """Create a new session.
@@ -102,8 +132,8 @@ async def delete_session(session_id: str) -> dict:
 async def send_prompt(session_id: str, request: PromptRequest) -> PromptResponse:
     """Send a prompt to a session.
 
-    For streaming responses, use the /sessions/{id}/prompt/stream endpoint.
-    This endpoint queues the message and returns immediately.
+    Runs the prompt and returns the complete response. For incremental output,
+    use the /sessions/{id}/prompt/stream endpoint.
 
     The `conflict_strategy` parameter controls behavior when the session is busy:
     - `queue`: Add the prompt to the queue (default)
@@ -170,7 +200,7 @@ async def send_prompt(session_id: str, request: PromptRequest) -> PromptResponse
 
         if is_busy:
             # Default: queue the message
-            position = session.agent.queued_count() + 1
+            position = await _enqueue_agent_prompt(session, routed.content, request)
 
             # Notify about queuing
             await _safe_emit(
@@ -196,10 +226,23 @@ async def send_prompt(session_id: str, request: PromptRequest) -> PromptResponse
             )
         )
 
+        response_text = ""
+        async for chunk in session_manager.prompt_session(
+            session_id=session_id,
+            content=routed.content,
+            stream=False,
+            priority=request.priority.value,
+        ):
+            if isinstance(chunk, str):
+                response_text += chunk
+            elif hasattr(chunk, "content"):
+                response_text += str(chunk.content)
+
         return PromptResponse(
             session_id=session_id,
             message_id=message_id,
-            status="streaming" if request.stream else "processing",
+            status="complete",
+            response=response_text,
         )
 
     except SessionNotFoundError:

--- a/src/amcp/server/session_manager.py
+++ b/src/amcp/server/session_manager.py
@@ -283,57 +283,58 @@ class SessionManager:
         """
         session = await self.get_session(session_id)
 
-        # Update status
-        session.update_status(SessionStatus.BUSY)
-        self._emit_event(
-            "session.status_changed",
-            {"session_id": session_id, "status": SessionStatus.BUSY.value},
-        )
-
-        try:
-            # Resolve work directory
-            effective_work_dir = work_dir or Path(session.cwd)
-
-            # Map priority string to enum
-            from ..message_queue import MessagePriority as MQPriority
-
-            priority_map = {
-                "low": MQPriority.LOW,
-                "normal": MQPriority.NORMAL,
-                "high": MQPriority.HIGH,
-                "urgent": MQPriority.URGENT,
-            }
-            mq_priority = priority_map.get(priority, MQPriority.NORMAL)
-
-            # Run the agent
-            # Note: Agent.run returns a string, not an async generator.
-            # For streaming support, the agent emits 'message.chunk' events via callbacks
-            # which are captured and forwarded by the EventBridge.
-            result = await session.agent.run(
-                user_input=content,
-                work_dir=effective_work_dir,
-                stream=stream,
-                show_progress=False,  # Server doesn't show progress
-                priority=mq_priority,
-            )
-            yield result
-
-            session.message_count += 1
-            session.update_status(SessionStatus.IDLE)
-
-        except Exception as e:
-            session.update_status(SessionStatus.ERROR)
-            self._emit_event(
-                "session.error",
-                {"session_id": session_id, "error": str(e)},
-            )
-            raise
-
-        finally:
+        async with session._lock:
+            # Update status
+            session.update_status(SessionStatus.BUSY)
             self._emit_event(
                 "session.status_changed",
-                {"session_id": session_id, "status": session.status.value},
+                {"session_id": session_id, "status": SessionStatus.BUSY.value},
             )
+
+            try:
+                # Resolve work directory
+                effective_work_dir = work_dir or Path(session.cwd)
+
+                # Map priority string to enum
+                from ..message_queue import MessagePriority as MQPriority
+
+                priority_map = {
+                    "low": MQPriority.LOW,
+                    "normal": MQPriority.NORMAL,
+                    "high": MQPriority.HIGH,
+                    "urgent": MQPriority.URGENT,
+                }
+                mq_priority = priority_map.get(priority, MQPriority.NORMAL)
+
+                # Run the agent
+                # Note: Agent.run returns a string, not an async generator.
+                # For streaming support, the agent emits 'message.chunk' events via callbacks
+                # which are captured and forwarded by the EventBridge.
+                result = await session.agent.run(
+                    user_input=content,
+                    work_dir=effective_work_dir,
+                    stream=stream,
+                    show_progress=False,  # Server doesn't show progress
+                    priority=mq_priority,
+                )
+                yield result
+
+                session.message_count += 1
+                session.update_status(SessionStatus.IDLE)
+
+            except Exception as e:
+                session.update_status(SessionStatus.ERROR)
+                self._emit_event(
+                    "session.error",
+                    {"session_id": session_id, "error": str(e)},
+                )
+                raise
+
+            finally:
+                self._emit_event(
+                    "session.status_changed",
+                    {"session_id": session_id, "status": session.status.value},
+                )
 
     async def cancel_session(self, session_id: str, force: bool = False) -> None:
         """Cancel the current operation in a session.

--- a/src/amcp/telegram/bot.py
+++ b/src/amcp/telegram/bot.py
@@ -535,21 +535,7 @@ class TelegramBot:
         session = self._session_manager.get_or_create_session(chat_id)
         session.last_used = datetime.now()
         queued_message = TelegramQueuedMessage(chat_id=chat_id, user_id=user_id, text=text)
-
-        if session.lock.locked():
-            if self._is_queue_full(session):
-                await self.send_text(chat_id, "Session queue is full. Please try again later.")
-                return
-            session.queue.append(queued_message)
-            await self.send_text(chat_id, "Session busy. Your message was queued.")
-            return
-
-        generation = getattr(session, "generation", 0)
-        async with session.lock:
-            await self._process_message(session, queued_message)
-            while session.queue and getattr(session, "generation", 0) == generation:
-                next_message = session.queue.popleft()
-                await self._process_message(session, next_message)
+        await self._enqueue_message(session, queued_message)
 
     async def handle_media(
         self, chat_id: int, user_id: int, text: str, message_type: str, metadata: dict[str, Any] | None
@@ -559,32 +545,102 @@ class TelegramBot:
         queued_message = TelegramQueuedMessage(
             chat_id=chat_id, user_id=user_id, text=text, message_type=message_type, metadata=metadata
         )
+        await self._enqueue_message(session, queued_message)
 
-        if session.lock.locked():
-            if self._is_queue_full(session):
-                await self.send_text(chat_id, "Session queue is full. Please try again later.")
+    async def _enqueue_message(self, session: Any, message: TelegramQueuedMessage) -> None:
+        queue_lock = self._get_session_queue_lock(session)
+        async with queue_lock:
+            active = self._session_worker_active(session)
+            if active and self._is_queue_full(session):
+                await self.send_text(message.chat_id, "Session queue is full. Please try again later.")
                 return
-            session.queue.append(queued_message)
-            await self.send_text(chat_id, "Session busy. Your message was queued.")
+
+            status_text = (
+                f"Session busy. Queued at position {len(session.queue) + 1}."
+                if active
+                else "Started processing your request..."
+            )
+            status_message = await self.send_text(message.chat_id, status_text)
+            message.status_message_id = self._get_telegram_message_id(status_message)
+            session.queue.append(message)
+
+            if not active:
+                generation = getattr(session, "generation", 0)
+                worker = asyncio.create_task(self._drain_session_queue(session, generation))
+                session.worker_task = worker
+                worker.add_done_callback(
+                    lambda task, bound_session=session: self._on_session_worker_done(bound_session, task)
+                )
+
+    @staticmethod
+    def _get_session_queue_lock(session: Any) -> asyncio.Lock:
+        lock = getattr(session, "queue_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            session.queue_lock = lock
+        return lock
+
+    @staticmethod
+    def _session_worker_active(session: Any) -> bool:
+        worker = getattr(session, "worker_task", None)
+        if worker and not worker.done():
+            return True
+        current = getattr(session, "current_task", None)
+        return bool(current and not current.done())
+
+    @staticmethod
+    def _get_telegram_message_id(message: Any) -> int | None:
+        message_id = getattr(message, "message_id", None)
+        return int(message_id) if message_id is not None else None
+
+    async def _drain_session_queue(self, session: Any, generation: int) -> None:
+        while getattr(session, "generation", 0) == generation:
+            queue_lock = self._get_session_queue_lock(session)
+            async with queue_lock:
+                if not session.queue:
+                    break
+                message = session.queue.popleft()
+
+            if message.status_message_id is not None:
+                await self._edit_text(message.chat_id, message.status_message_id, "Processing...")
+            await self._process_message(session, message)
+
+    def _on_session_worker_done(self, session: Any, task: asyncio.Task[None]) -> None:
+        if getattr(session, "worker_task", None) is task:
+            session.worker_task = None
+        if task.cancelled():
             return
+        try:
+            task.result()
+        except Exception:
+            logger.exception("Telegram session worker failed.")
 
-        generation = getattr(session, "generation", 0)
-        async with session.lock:
-            await self._process_message(session, queued_message)
-            while session.queue and getattr(session, "generation", 0) == generation:
-                next_message = session.queue.popleft()
-                await self._process_message(session, next_message)
+    async def send_text(self, chat_id: int, text: str) -> Any:
+        return await self._application.bot.send_message(chat_id=chat_id, text=text)
 
-    async def send_text(self, chat_id: int, text: str) -> None:
-        await self._application.bot.send_message(chat_id=chat_id, text=text)
-
-    async def send_markdown(self, chat_id: int, text: str) -> None:
-        await self._application.bot.send_message(
+    async def send_markdown(self, chat_id: int, text: str) -> Any:
+        return await self._application.bot.send_message(
             chat_id=chat_id,
             text=text,
             parse_mode="MarkdownV2",
             disable_web_page_preview=True,
         )
+
+    async def _edit_text(self, chat_id: int, message_id: int, text: str, *, markdown: bool = False) -> bool:
+        try:
+            kwargs: dict[str, Any] = {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "text": text,
+            }
+            if markdown:
+                kwargs["parse_mode"] = "MarkdownV2"
+                kwargs["disable_web_page_preview"] = True
+            await self._application.bot.edit_message_text(**kwargs)
+            return True
+        except Exception as exc:
+            logger.debug("Failed to edit Telegram status message %s/%s: %s", chat_id, message_id, exc)
+            return False
 
     async def send_notification(self, text: str) -> None:
         if self._loop and asyncio.get_running_loop() is not self._loop:
@@ -610,6 +666,7 @@ class TelegramBot:
     async def _process_message(self, session: Any, message: TelegramQueuedMessage) -> None:
         generation = getattr(session, "generation", 0)
         task: asyncio.Task | None = None
+        status_message_id = message.status_message_id
         self._bind_session_memory(message.chat_id, session)
         async with self._typing_session(message.chat_id):
             try:
@@ -626,21 +683,37 @@ class TelegramBot:
                 response = await task
             except asyncio.CancelledError:
                 if getattr(session, "generation", 0) == generation:
-                    await self.send_text(message.chat_id, "Request cancelled.")
+                    await self._deliver_status_or_text(
+                        message.chat_id,
+                        status_message_id,
+                        "Request cancelled.",
+                    )
                 return
             except BusyError:
                 if getattr(session, "generation", 0) != generation:
                     return
                 if self._is_queue_full(session):
-                    await self.send_text(message.chat_id, "Session queue is full. Please try again later.")
+                    await self._deliver_status_or_text(
+                        message.chat_id,
+                        status_message_id,
+                        "Session queue is full. Please try again later.",
+                    )
                 else:
                     session.queue.appendleft(message)
-                    await self.send_text(message.chat_id, "Session busy. Your message was queued.")
+                    await self._deliver_status_or_text(
+                        message.chat_id,
+                        status_message_id,
+                        "Session busy. Your message was queued.",
+                    )
                 return
             except Exception as exc:
                 logger.exception("Failed to process Telegram message.")
                 if getattr(session, "generation", 0) == generation:
-                    await self.send_markdown(message.chat_id, self._formatter.format_error(str(exc)))
+                    await self._deliver_status_or_markdown(
+                        message.chat_id,
+                        status_message_id,
+                        self._formatter.format_error(str(exc)),
+                    )
                 return
             finally:
                 if getattr(session, "current_task", None) is task:
@@ -650,10 +723,10 @@ class TelegramBot:
             if getattr(session, "generation", 0) != generation:
                 return
             if response_text:
-                for chunk in self._formatter.format_response(response_text):
-                    if getattr(session, "generation", 0) != generation:
-                        return
-                    await self.send_markdown(message.chat_id, chunk)
+                chunks = self._formatter.format_response(response_text)
+                await self._deliver_response_chunks(message.chat_id, status_message_id, chunks, generation, session)
+            elif status_message_id is not None:
+                await self._edit_text(message.chat_id, status_message_id, "Done.")
 
         if getattr(session, "generation", 0) != generation:
             return
@@ -664,6 +737,36 @@ class TelegramBot:
             tags=["telegram", "conversation"],
             scope="project",
         )
+
+    async def _deliver_status_or_text(self, chat_id: int, message_id: int | None, text: str) -> None:
+        if message_id is not None and await self._edit_text(chat_id, message_id, text):
+            return
+        await self.send_text(chat_id, text)
+
+    async def _deliver_status_or_markdown(self, chat_id: int, message_id: int | None, text: str) -> None:
+        if message_id is not None and await self._edit_text(chat_id, message_id, text, markdown=True):
+            return
+        await self.send_markdown(chat_id, text)
+
+    async def _deliver_response_chunks(
+        self,
+        chat_id: int,
+        message_id: int | None,
+        chunks: list[str],
+        generation: int,
+        session: Any,
+    ) -> None:
+        if not chunks:
+            return
+
+        start_idx = 0
+        if message_id is not None and await self._edit_text(chat_id, message_id, chunks[0], markdown=True):
+            start_idx = 1
+
+        for chunk in chunks[start_idx:]:
+            if getattr(session, "generation", 0) != generation:
+                return
+            await self.send_markdown(chat_id, chunk)
 
     @staticmethod
     def _trim_memory_log_text(text: str, limit: int) -> str:

--- a/src/amcp/telegram/handlers.py
+++ b/src/amcp/telegram/handlers.py
@@ -27,8 +27,10 @@ class TelegramSession:
     agent: Any
     last_used: datetime = field(default_factory=datetime.now)
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    queue_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     queue: deque[TelegramQueuedMessage] = field(default_factory=deque)
     current_task: asyncio.Task | None = None
+    worker_task: asyncio.Task | None = None
     generation: int = 0
 
 
@@ -39,6 +41,7 @@ class TelegramQueuedMessage:
     text: str = ""
     message_type: str = "text"
     metadata: dict[str, Any] | None = None
+    status_message_id: int | None = None
 
 
 def _format_photo_message(message: Any) -> tuple[str, dict[str, Any] | None]:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,16 +1,21 @@
 """Tests for AMCP Server module."""
 
+import asyncio
 import json
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi.testclient import TestClient
 
+from amcp.message_queue import get_message_queue_manager
 from amcp.server import ServerConfig, create_app
+from amcp.server.models import SessionStatus
 from amcp.server.session_manager import (
     ManagedSession,
     MaxSessionsReachedError,
     SessionManager,
     SessionNotFoundError,
+    get_session_manager,
 )
 
 
@@ -161,6 +166,46 @@ class TestSessionEndpoints:
         assert data["status"] == "handled"
         assert data["new_session_id"]
         assert data["new_session_id"] != session_id
+
+    def test_prompt_non_stream_executes_agent_and_returns_response(self, client):
+        """Test non-stream prompt endpoint runs the agent and returns its response."""
+        create_resp = client.post("/api/v1/sessions", json={"cwd": "/tmp"})
+        session_id = create_resp.json()["id"]
+        managed = asyncio.run(get_session_manager().get_session(session_id))
+        managed.agent.run = AsyncMock(return_value="server response")
+
+        response = client.post(
+            f"/api/v1/sessions/{session_id}/prompt",
+            json={"content": "hello", "stream": False},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "complete"
+        assert data["response"] == "server response"
+        managed.agent.run.assert_awaited_once()
+        assert managed.agent.run.await_args.kwargs["user_input"] == "hello"
+        assert managed.agent.run.await_args.kwargs["stream"] is False
+
+    def test_prompt_non_stream_busy_queue_actually_enqueues(self, client):
+        """Test busy non-stream prompt endpoint enqueues the prompt before returning queued."""
+        create_resp = client.post("/api/v1/sessions", json={"cwd": "/tmp"})
+        session_id = create_resp.json()["id"]
+        managed = asyncio.run(get_session_manager().get_session(session_id))
+        managed.update_status(SessionStatus.BUSY)
+
+        response = client.post(
+            f"/api/v1/sessions/{session_id}/prompt",
+            json={"content": "queued prompt", "stream": False, "conflict_strategy": "queue"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "queued"
+        assert data["position"] == 1
+        assert managed.agent.queued_count() == 1
+        assert get_message_queue_manager().queued_prompts(managed.agent.session_id) == ["queued prompt"]
+        asyncio.run(managed.agent.clear_queue())
 
 
 class TestToolEndpoints:
@@ -460,6 +505,8 @@ class TestConflictStrategy:
         # Create a session
         create_resp = client.post("/api/v1/sessions", json={"cwd": "/tmp"})
         session_id = create_resp.json()["id"]
+        managed = asyncio.run(get_session_manager().get_session(session_id))
+        managed.agent.run = AsyncMock(return_value="queued strategy response")
 
         # Send prompt with queue strategy (default)
         response = client.post(
@@ -469,13 +516,16 @@ class TestConflictStrategy:
         assert response.status_code == 200
         data = response.json()
         assert data["session_id"] == session_id
-        assert data["status"] in ["streaming", "processing", "queued"]
+        assert data["status"] == "complete"
+        assert data["response"] == "queued strategy response"
 
     def test_prompt_with_reject_strategy_on_idle_session(self, client):
         """Test prompt with reject strategy on idle session succeeds."""
         # Create a session
         create_resp = client.post("/api/v1/sessions", json={"cwd": "/tmp"})
         session_id = create_resp.json()["id"]
+        managed = asyncio.run(get_session_manager().get_session(session_id))
+        managed.agent.run = AsyncMock(return_value="reject strategy response")
 
         # Send prompt with reject strategy - should succeed since session is idle
         response = client.post(
@@ -484,4 +534,5 @@ class TestConflictStrategy:
         )
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] in ["streaming", "processing"]
+        assert data["status"] == "complete"
+        assert data["response"] == "reject strategy response"

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -498,7 +499,10 @@ def _make_bot_for_typing(
     mock_app = MagicMock()
     mock_app.bot = MagicMock()
     mock_app.bot.send_chat_action = AsyncMock()
-    mock_app.bot.send_message = AsyncMock()
+    message_ids = iter(range(1, 1000))
+    mock_app.bot.send_message = AsyncMock(side_effect=lambda **kwargs: SimpleNamespace(message_id=next(message_ids)))
+    mock_app.bot.edit_message_text = AsyncMock()
+    importlib.import_module("amcp.telegram.bot")
 
     with (
         patch("amcp.telegram.bot.ApplicationBuilder") as builder_cls,
@@ -723,6 +727,98 @@ def test_typing_stop_all():
         await bot._stop_all_typing()
 
         assert len(bot._typing_tasks) == 0
+
+    asyncio.run(_run())
+
+
+def test_handle_prompt_starts_background_worker_and_returns():
+    async def _run():
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        class _SlowAgent:
+            def __init__(self, session_id: str) -> None:
+                self.session_id = session_id
+                self.execution_context = {}
+
+            async def run(self, **kwargs):
+                started.set()
+                await release.wait()
+                return "done"
+
+        bot = _make_bot_for_typing(agent_factory=_SlowAgent)
+
+        await bot.handle_prompt(900, 1, "hi")
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        session = bot._session_manager.get_current_session(900)
+        assert session is not None
+        assert session.worker_task is not None
+        assert not session.worker_task.done()
+        assert session.current_task is not None
+        assert not session.current_task.done()
+        assert (
+            bot._application.bot.send_message.call_args_list[0].kwargs["text"] == "Started processing your request..."
+        )
+
+        release.set()
+        await session.worker_task
+
+        bot._application.bot.edit_message_text.assert_any_call(
+            chat_id=900,
+            message_id=1,
+            text="done",
+            parse_mode="MarkdownV2",
+            disable_web_page_preview=True,
+        )
+
+    asyncio.run(_run())
+
+
+def test_handle_prompt_queues_follow_up_for_same_session():
+    async def _run():
+        first_started = asyncio.Event()
+        first_release = asyncio.Event()
+        calls: list[str] = []
+
+        class _QueuedAgent:
+            def __init__(self, session_id: str) -> None:
+                self.session_id = session_id
+                self.execution_context = {}
+
+            async def run(self, **kwargs):
+                calls.append(kwargs["user_input"])
+                if len(calls) == 1:
+                    first_started.set()
+                    await first_release.wait()
+                return f"reply {len(calls)}"
+
+        bot = _make_bot_for_typing(agent_factory=_QueuedAgent)
+
+        await bot.handle_prompt(901, 1, "first")
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+        await bot.handle_prompt(901, 1, "second")
+
+        session = bot._session_manager.get_current_session(901)
+        assert session is not None
+        worker = session.worker_task
+        assert worker is not None
+        assert len(session.queue) == 1
+        assert bot._application.bot.send_message.call_args_list[1].kwargs["text"] == (
+            "Session busy. Queued at position 1."
+        )
+
+        first_release.set()
+        await worker
+
+        assert calls == ["first", "second"]
+        bot._application.bot.edit_message_text.assert_any_call(
+            chat_id=901,
+            message_id=2,
+            text="reply 2",
+            parse_mode="MarkdownV2",
+            disable_web_page_preview=True,
+        )
 
     asyncio.run(_run())
 


### PR DESCRIPTION
# Pull Request

## Description
Fixes session orchestration consistency for server and Telegram entrypoints:

- Telegram prompt/media handlers now acknowledge immediately, enqueue work, and process each Telegram session in a background worker.
- Telegram responses edit the original placeholder message when possible, falling back to sending a new message.
- Server non-stream `/sessions/{id}/prompt` now actually executes the agent and returns the complete response.
- Busy server sessions with queue strategy now enqueue the prompt instead of returning a queued status without storing work.
- Server session execution is serialized per session while preserving parallelism across different sessions.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Testing
```bash
uv run --extra dev --extra telegram pytest -q
uv run --extra dev ruff check src/amcp/server/session_manager.py src/amcp/server/routes/sessions.py src/amcp/telegram tests/test_server.py tests/test_telegram.py
uv run --extra dev ruff format --check src/amcp/server/session_manager.py src/amcp/server/routes/sessions.py src/amcp/telegram tests/test_server.py tests/test_telegram.py
```

## Related Issues
N/A
