### PR TITLE
feat: migrate LLM providers to any-llm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "pydantic>=2.7",
   "fastmcp>=2.0.0,<3",
   "tomli-w>=1.0.0",
-  "openai>=1.52.0",
+  "any-llm-sdk>=1.21.0,<2",
   "pyyaml>=6.0",
   "prompt-toolkit>=3.0.0",
   "agent-client-protocol>=0.7.0",
@@ -51,7 +51,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-anthropic = ["anthropic>=0.40.0"]
+anthropic = []
 telegram = [
   "python-telegram-bot>=21.0",
   "requests>=2.31.0",
@@ -65,7 +65,6 @@ dev = [
   "ruff>=0.3.0",
   "mypy>=1.8.0",
   "types-PyYAML>=6.0.0",
-  "anthropic>=0.40.0",
   "telegramify-markdown>=1.0.0,<2",
 ]
 

--- a/src/amcp/agent.py
+++ b/src/amcp/agent.py
@@ -9,6 +9,7 @@ import logging
 import time
 import uuid
 from collections.abc import Callable
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -18,7 +19,6 @@ from rich.status import Status
 from rich.text import Text
 
 from .agent_spec import ResolvedAgentSpec, get_default_agent_spec
-from .chat import _make_client, _resolve_api_key, _resolve_base_url
 from .compaction import (
     CompactionConfig,
     SmartCompactor,
@@ -26,7 +26,7 @@ from .compaction import (
     estimate_tokens,
     get_model_context_window,
 )
-from .config import AMCPConfig, ContextConfig, ModelConfig, load_config
+from .config import AMCPConfig, ChatConfig, ContextConfig, ModelConfig, load_config
 from .hooks import (
     HookDecision,
     run_post_tool_use_hooks,
@@ -767,10 +767,15 @@ class Agent:
 
                 # Apply compaction if context is too large
                 cfg = load_config()
-                base_url = _resolve_base_url(self.agent_spec.base_url or None, cfg.chat)
-                api_key = _resolve_api_key(None, cfg.chat)
-                client = _make_client(base_url, api_key)
                 model = self._resolve_model_name(cfg)
+                compaction_chat = replace(cfg.chat) if cfg.chat else ChatConfig()
+                compaction_chat.model = model
+                if self.agent_spec.base_url:
+                    compaction_chat.base_url = self.agent_spec.base_url
+
+                from .llm import create_llm_client
+
+                client = create_llm_client(compaction_chat)
                 compactor = SmartCompactor(
                     client,
                     model,
@@ -878,10 +883,15 @@ class Agent:
         """
         try:
             cfg = load_config()
-            base_url = _resolve_base_url(self.agent_spec.base_url or None, cfg.chat)
-            api_key = _resolve_api_key(None, cfg.chat)
-            client = _make_client(base_url, api_key)
             model = cfg.chat.model if cfg.chat and cfg.chat.model else "DeepSeek-V3.1-Terminus"
+            memory_chat = replace(cfg.chat) if cfg.chat else ChatConfig()
+            memory_chat.model = model
+            if self.agent_spec.base_url:
+                memory_chat.base_url = self.agent_spec.base_url
+
+            from .llm import create_llm_client
+
+            client = create_llm_client(memory_chat)
 
             # Build memory-only tool list from the global registry
             from .tools import get_tool_registry

--- a/src/amcp/chat.py
+++ b/src/amcp/chat.py
@@ -4,12 +4,8 @@ from __future__ import annotations
 
 import os
 
-from rich.console import Console
-
 from .config import ChatConfig
-from .llm import AMCP_USER_AGENT
-
-console = Console()
+from .llm import AnyLLMClient
 
 
 def _resolve_base_url(cli_base: str | None, cfg: ChatConfig | None) -> str:
@@ -34,14 +30,17 @@ def _resolve_api_key(cli_key: str | None, cfg: ChatConfig | None) -> str | None:
     return os.environ.get("OPENAI_API_KEY")
 
 
-def _make_client(base_url: str, api_key: str | None):
-    try:
-        from openai import OpenAI
-    except ImportError:  # pragma: no cover
-        console.print("[red]openai package not installed. Please install dependencies.[/red]")
-        raise
-    return OpenAI(
+def _make_client(
+    base_url: str,
+    api_key: str | None,
+    *,
+    provider: str = "openai",
+    model: str = "gpt-4o",
+) -> AnyLLMClient:
+    """Create the shared any-llm completion client."""
+    return AnyLLMClient(
+        provider=provider,
         base_url=base_url,
-        api_key=api_key or "",
-        default_headers={"User-Agent": AMCP_USER_AGENT},
+        api_key=api_key,
+        model=model,
     )

--- a/src/amcp/compaction.py
+++ b/src/amcp/compaction.py
@@ -42,8 +42,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from openai import OpenAI
-
 if TYPE_CHECKING:
     from .config import ModelConfig
 
@@ -397,7 +395,7 @@ class SmartCompactor:
 
     def __init__(
         self,
-        client: OpenAI,
+        client: Any,
         model: str,
         config: CompactionConfig | None = None,
         model_config: ModelConfig | None = None,
@@ -405,7 +403,7 @@ class SmartCompactor:
         """Initialize the smart compactor.
 
         Args:
-            client: OpenAI client for generating summaries
+            client: AMCP LLM client for generating summaries
             model: Model name for context window detection
             config: Optional compaction configuration
             model_config: Optional ModelConfig with explicit user overrides
@@ -602,8 +600,7 @@ class SmartCompactor:
         )
 
         try:
-            resp = self.client.chat.completions.create(
-                model=self.model,
+            resp = self.client.chat(
                 messages=[
                     {
                         "role": "system",
@@ -614,7 +611,7 @@ class SmartCompactor:
                 max_tokens=min(4000, self.target_tokens),
                 temperature=0.3,  # Lower temperature for consistent summaries
             )
-            summary = resp.choices[0].message.content or ""
+            summary = resp.content or ""
         except Exception as e:
             logger.warning(f"LLM summarization failed: {e}, falling back to truncation")
             return self._truncate(messages)
@@ -708,8 +705,7 @@ class SmartCompactor:
         # Summarize removed messages
         try:
             context = _messages_to_text(removed)
-            resp = self.client.chat.completions.create(
-                model=self.model,
+            resp = self.client.chat(
                 messages=[
                     {"role": "system", "content": "Summarize this conversation context in 2-3 paragraphs."},
                     {"role": "user", "content": context[:10000]},  # Limit input
@@ -717,7 +713,7 @@ class SmartCompactor:
                 max_tokens=500,
                 temperature=0.3,
             )
-            summary = resp.choices[0].message.content or ""
+            summary = resp.content or ""
         except Exception:
             summary = f"[{len(removed)} older messages summarized]"
 
@@ -762,7 +758,7 @@ Compactor = SmartCompactor
 
 
 def create_compactor(
-    client: OpenAI,
+    client: Any,
     model: str,
     strategy: str = "summary",
     threshold_ratio: float = 0.7,
@@ -772,7 +768,7 @@ def create_compactor(
     """Create a smart compactor with custom settings.
 
     Args:
-        client: OpenAI client
+        client: AMCP LLM client
         model: Model name
         strategy: Compaction strategy ("summary", "truncate", "sliding_window", "hybrid")
         threshold_ratio: When to trigger compaction (ratio of context window)

--- a/src/amcp/config.py
+++ b/src/amcp/config.py
@@ -65,7 +65,7 @@ class ChatProviderConfig:
     base_url: str | None = None
     model: str | None = None
     api_key: str | None = None
-    api_type: str | None = None  # "openai" (default), "openai_responses", or "anthropic"
+    api_type: str | None = None  # any-llm provider ID, or "openai_responses"
     model_config: ModelConfig | None = None
 
 
@@ -74,7 +74,7 @@ class ChatConfig:
     base_url: str | None = None
     model: str | None = None
     api_key: str | None = None
-    api_type: str | None = None  # "openai" (default) or "anthropic"
+    api_type: str | None = None  # any-llm provider ID, or "openai_responses"
 
     # Model configuration (from models.dev or custom)
     model_config: ModelConfig | None = None
@@ -227,7 +227,7 @@ _DEFAULT = {
             "gmi": {
                 "base_url": "https://api.gmi-serving.com/v1",
                 "model": "openai/gpt-5.5",
-                "api_type": "openai",
+                "api_type": "gmi",
                 "model_config": {
                     "provider_id": "gmi",
                     "model_id": "openai/gpt-5.5",
@@ -367,6 +367,15 @@ def _apply_active_provider(chat: ChatConfig) -> ChatConfig:
     chat.base_url = provider.base_url
     chat.model = provider.model
     chat.api_key = provider.api_key
+    if chat.api_key is None and provider.base_url:
+        chat.api_key = next(
+            (
+                candidate.api_key
+                for candidate in chat.providers.values()
+                if candidate.base_url == provider.base_url and candidate.api_key
+            ),
+            None,
+        )
     chat.api_type = provider.api_type
     chat.model_config = provider.model_config
     return chat

--- a/src/amcp/init_wizard.py
+++ b/src/amcp/init_wizard.py
@@ -141,6 +141,18 @@ def prompt_api_key(provider_name: str, env_vars: list[str]) -> str:
     return console.input("API Key: ").strip()
 
 
+def _resolve_api_type(provider_id: str, is_custom: bool) -> str:
+    """Use a native any-llm provider when available, otherwise OpenAI compatibility."""
+    if is_custom:
+        return "openai"
+
+    from any_llm import AnyLLM
+
+    if provider_id in AnyLLM.get_supported_providers():
+        return provider_id
+    return "openai"
+
+
 def download_models_database() -> ModelsDatabase | None:
     """Download models database from models.dev with progress indicator."""
     console.print("\n[bold]Downloading model database from models.dev...[/bold]")
@@ -555,12 +567,13 @@ def run_init_wizard() -> Path:
         output_limit=output_limit,
         is_custom=is_custom,
     )
+    api_type = _resolve_api_type(provider_id, is_custom)
 
     chat_config = ChatConfig(
         base_url=base_url,
         model=model_id,
         api_key=api_key if api_key else None,
-        api_type="openai",
+        api_type=api_type,
         model_config=model_config,
         active_provider=provider_id,
         providers={
@@ -568,7 +581,7 @@ def run_init_wizard() -> Path:
                 base_url=base_url,
                 model=model_id,
                 api_key=api_key if api_key else None,
-                api_type="openai",
+                api_type=api_type,
                 model_config=model_config,
             )
         },

--- a/src/amcp/llm.py
+++ b/src/amcp/llm.py
@@ -1,21 +1,18 @@
-"""LLM client abstraction supporting OpenAI, OpenAI Responses, and Anthropic APIs."""
+"""Unified LLM client abstraction built on any-llm."""
 
 from __future__ import annotations
 
-import json
 import os
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from .config import ChatConfig
 
 # Type aliases for commonly used complex types
 ToolCall = dict[str, Any]
 Message = dict[str, Any]
-
-AMCP_USER_AGENT = "AMCPAgent"
 
 
 def _extract_think_tags(content: str) -> tuple[str | None, str]:
@@ -67,6 +64,19 @@ def _split_response_content(
         return reasoning_content, content
 
     return thinking_from_content, content
+
+
+def _reasoning_content(value: Any) -> str | None:
+    """Read normalized any-llm reasoning, with legacy provider fallback."""
+    reasoning = _response_field(value, "reasoning")
+    if isinstance(reasoning, str):
+        return reasoning
+    if reasoning is not None:
+        content = _response_field(reasoning, "content")
+        if content:
+            return str(content)
+    legacy = _response_field(value, "reasoning_content")
+    return str(legacy) if legacy else None
 
 
 @dataclass
@@ -146,23 +156,6 @@ def _responses_usage(usage: Any) -> TokenUsage | None:
     )
 
 
-def _anthropic_usage(usage: Any) -> TokenUsage | None:
-    """Normalize Anthropic usage, including prompt-cache tokens."""
-    if usage is None:
-        return None
-    uncached_input = _usage_value(usage, "input_tokens")
-    cache_creation = _usage_value(usage, "cache_creation_input_tokens")
-    cache_read = _usage_value(usage, "cache_read_input_tokens")
-    output_tokens = _usage_value(usage, "output_tokens")
-    return TokenUsage(
-        input_tokens=uncached_input,
-        output_tokens=output_tokens,
-        total_tokens=uncached_input + cache_creation + cache_read + output_tokens,
-        cached_input_tokens=cache_read,
-        cache_write_input_tokens=cache_creation,
-    )
-
-
 class BaseLLMClient(ABC):
     """Base class for LLM clients."""
 
@@ -180,17 +173,20 @@ class BaseLLMClient(ABC):
         pass
 
 
-class OpenAIClient(BaseLLMClient):
-    """OpenAI Chat Completions API client."""
+class AnyLLMClient(BaseLLMClient):
+    """Completion client for any provider supported by any-llm."""
 
-    def __init__(self, base_url: str, api_key: str | None, model: str):
-        from openai import OpenAI
+    def __init__(
+        self,
+        provider: str,
+        base_url: str | None,
+        api_key: str | None,
+        model: str,
+    ):
+        from any_llm import AnyLLM
 
-        self.client = OpenAI(
-            base_url=base_url,
-            api_key=api_key or "",
-            default_headers={"User-Agent": AMCP_USER_AGENT},
-        )
+        self.client = AnyLLM.create(provider, api_key=api_key, api_base=base_url)
+        self.provider = provider
         self.model = model
 
     def chat(
@@ -200,21 +196,22 @@ class OpenAIClient(BaseLLMClient):
         stream_callback: Any | None = None,
         **kwargs,
     ) -> LLMResponse:
-        params: dict[str, Any] = {"model": self.model, "messages": messages, "stream": bool(stream_callback), **kwargs}
+        model = kwargs.pop("model", self.model)
+        callback = stream_callback
+        stream = callback is not None
+        params: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "stream": stream,
+            "allow_running_loop": True,
+            **kwargs,
+        }
         if tools:
             params["tools"] = tools
             params["tool_choice"] = "auto"
-            # When tools are present, we usually don't stream content to avoid complications,
-            # or we need to handle tool call streaming separately.
-            # For simplicity, if tools are present, we disable streaming unless specifically handled.
-            # However, user wants streaming prompt responses.
-            # OpenAI supports streaming tool calls, but it's complex.
-            # Let's support streaming content only if tools are NOT likely to be called immediately
-            # or accept that we might stream mixed content.
-            # For now, let's keep streaming enabled if requested, but handle tool chunks carefully.
-            # Note: The 'stream' param in params dict controls API behavior.
 
-        if stream_callback:
+        if stream:
+            assert callback is not None
             # Streaming mode
             accumulated_content = []
             accumulated_reasoning = []
@@ -222,40 +219,49 @@ class OpenAIClient(BaseLLMClient):
             finish_reason = None
             usage = None
 
-            response = self.client.chat.completions.create(**params)
+            response = self.client.completion(**params)
 
             for chunk in response:
-                if getattr(chunk, "usage", None) is not None:
-                    usage = _openai_chat_usage(chunk.usage)
+                chunk_usage = _response_field(chunk, "usage")
+                if chunk_usage is not None:
+                    usage = _openai_chat_usage(chunk_usage)
                 # Some APIs (e.g., DeepSeek) may return chunks with empty choices
-                if not chunk.choices:
+                choices = _response_field(chunk, "choices")
+                if not choices:
                     continue
-                delta = chunk.choices[0].delta
-                finish_reason = chunk.choices[0].finish_reason
+                delta = _response_field(choices[0], "delta")
+                finish_reason = _response_field(choices[0], "finish_reason")
 
                 # Handle content
-                if delta.content:
-                    stream_callback(delta.content)
-                    accumulated_content.append(delta.content)
+                delta_content = _response_field(delta, "content")
+                if delta_content:
+                    callback(delta_content)
+                    accumulated_content.append(delta_content)
 
                 # Handle thinking (if present in specific fields)
-                if hasattr(delta, "reasoning_content") and delta.reasoning_content:
-                    accumulated_reasoning.append(delta.reasoning_content)
+                delta_reasoning = _reasoning_content(delta)
+                if delta_reasoning:
+                    accumulated_reasoning.append(delta_reasoning)
 
                 # Handle tool calls (accumulate them)
-                if delta.tool_calls:
-                    for tc in delta.tool_calls:
-                        idx = tc.index
+                delta_tool_calls = _response_field(delta, "tool_calls")
+                if delta_tool_calls:
+                    for tc in delta_tool_calls:
+                        idx = _response_field(tc, "index", 0)
                         if idx not in tool_calls_chunks:
                             tool_calls_chunks[idx] = {"id": "", "name": "", "arguments": ""}
 
-                        if tc.id:
-                            tool_calls_chunks[idx]["id"] += tc.id
-                        if tc.function:
-                            if tc.function.name:
-                                tool_calls_chunks[idx]["name"] += tc.function.name
-                            if tc.function.arguments:
-                                tool_calls_chunks[idx]["arguments"] += tc.function.arguments
+                        tool_call_id = _response_field(tc, "id")
+                        if tool_call_id:
+                            tool_calls_chunks[idx]["id"] += tool_call_id
+                        function = _response_field(tc, "function")
+                        if function:
+                            name = _response_field(function, "name")
+                            arguments = _response_field(function, "arguments")
+                            if name:
+                                tool_calls_chunks[idx]["name"] += name
+                            if arguments:
+                                tool_calls_chunks[idx]["arguments"] += arguments
 
             # Reconstruct full response
             content = "".join(accumulated_content) if accumulated_content else None
@@ -268,7 +274,7 @@ class OpenAIClient(BaseLLMClient):
                     tool_calls.append({"id": tc["id"], "name": tc["name"], "arguments": tc["arguments"]})
 
             if reasoning_text and not content and not tool_calls:
-                stream_callback(reasoning_text)
+                callback(reasoning_text)
 
             thinking, content = _split_response_content(
                 content,
@@ -285,23 +291,28 @@ class OpenAIClient(BaseLLMClient):
             )
 
         else:
-            # Non-streaming mode (existing logic)
-            resp = self.client.chat.completions.create(**params)
+            resp = self.client.completion(**params)
             first_choice = _first_chat_choice(resp)
             msg = _response_field(first_choice, "message")
             if msg is None:
                 raise ValueError("Provider returned a chat completion choice without a message.")
 
             tool_calls = None
-            if hasattr(msg, "tool_calls") and msg.tool_calls:
+            message_tool_calls = _response_field(msg, "tool_calls")
+            if message_tool_calls:
                 tool_calls = [
-                    {"id": tc.id, "name": tc.function.name, "arguments": tc.function.arguments} for tc in msg.tool_calls
+                    {
+                        "id": _response_field(tc, "id"),
+                        "name": _response_field(_response_field(tc, "function"), "name"),
+                        "arguments": _response_field(_response_field(tc, "function"), "arguments", "{}"),
+                    }
+                    for tc in message_tool_calls
                 ]
 
             # Extract thinking content
             thinking, content = _split_response_content(
                 _response_field(msg, "content"),
-                _response_field(msg, "reasoning_content"),
+                _reasoning_content(msg),
                 allow_reasoning_as_content=tool_calls is None,
             )
 
@@ -310,21 +321,31 @@ class OpenAIClient(BaseLLMClient):
                 tool_calls=tool_calls,
                 stop_reason=_response_field(first_choice, "finish_reason"),
                 thinking=thinking,
-                usage=_openai_chat_usage(getattr(resp, "usage", None)),
+                usage=_openai_chat_usage(_response_field(resp, "usage")),
             )
 
 
-class OpenAIResponsesClient(BaseLLMClient):
-    """OpenAI Responses API client."""
+class OpenAIClient(AnyLLMClient):
+    """Backward-compatible OpenAI completion client."""
 
     def __init__(self, base_url: str, api_key: str | None, model: str):
-        from openai import OpenAI
+        super().__init__("openai", base_url, api_key, model)
 
-        self.client = OpenAI(
-            base_url=base_url,
-            api_key=api_key or "",
-            default_headers={"User-Agent": AMCP_USER_AGENT},
-        )
+
+class AnthropicClient(AnyLLMClient):
+    """Backward-compatible Anthropic completion client."""
+
+    def __init__(self, api_key: str | None, model: str, base_url: str | None = None):
+        super().__init__("anthropic", base_url, api_key, model)
+
+
+class OpenAIResponsesClient(BaseLLMClient):
+    """OpenAI Responses API client backed by any-llm."""
+
+    def __init__(self, base_url: str, api_key: str | None, model: str):
+        from any_llm import AnyLLM
+
+        self.client = AnyLLM.create("openai", api_key=api_key, api_base=base_url)
         self.model = model
 
     def chat(
@@ -347,160 +368,142 @@ class OpenAIResponsesClient(BaseLLMClient):
                 for t in tools
             ]
 
-        params = {"model": self.model, "input": messages}
-        if resp_tools:
-            params["tools"] = resp_tools
+        model = kwargs.pop("model", self.model)
+        max_tokens = kwargs.pop("max_tokens", None)
+        params: dict[str, Any] = {
+            "model": model,
+            "input_data": cast(Any, self._convert_messages(messages)),
+            "tools": resp_tools,
+            "allow_running_loop": True,
+            **kwargs,
+        }
+        if max_tokens is not None:
+            params["max_output_tokens"] = max_tokens
 
-        resp = self.client.responses.create(**params)  # type: ignore[call-overload]
+        if stream_callback:
+            completed_response = None
+            for event in self.client.responses(stream=True, **params):
+                event_type = _response_field(event, "type")
+                if event_type == "response.output_text.delta":
+                    delta = _response_field(event, "delta")
+                    if delta:
+                        stream_callback(delta)
+                elif event_type == "response.completed":
+                    completed_response = _response_field(event, "response")
+            if completed_response is None:
+                raise ValueError("Provider response stream ended without a completed response.")
+            return self._parse_response(completed_response)
+
+        resp = self.client.responses(**params)
+        return self._parse_response(resp)
+
+    @staticmethod
+    def _convert_messages(messages: list[Message]) -> list[Message]:
+        """Convert AMCP Chat Completions history to Responses input items."""
+        converted: list[Message] = []
+        for message in messages:
+            role = message.get("role")
+            if role == "tool":
+                converted.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": message.get("tool_call_id"),
+                        "output": message.get("content", ""),
+                    }
+                )
+                continue
+
+            message_tool_calls = message.get("tool_calls")
+            if role == "assistant" and message_tool_calls:
+                if message.get("content"):
+                    converted.append({"role": "assistant", "content": message["content"]})
+                for tool_call in message_tool_calls:
+                    function = tool_call.get("function", {})
+                    converted.append(
+                        {
+                            "type": "function_call",
+                            "call_id": tool_call.get("id"),
+                            "name": function.get("name"),
+                            "arguments": function.get("arguments", "{}"),
+                        }
+                    )
+                continue
+
+            converted.append({"role": role, "content": message.get("content", "")})
+        return converted
+
+    @staticmethod
+    def _parse_response(resp: Any) -> LLMResponse:
+        """Normalize an any-llm Responses result."""
 
         # Parse response
         content_parts = []
         tool_calls = []
 
-        for item in resp.output:
-            if item.type == "message":
-                for block in item.content:
-                    if block.type == "output_text":
-                        content_parts.append(block.text)
-            elif item.type == "function_call":
-                tool_calls.append({"id": item.call_id, "name": item.name, "arguments": item.arguments})
-
-        return LLMResponse(
-            content="\n".join(content_parts) if content_parts else None,
-            tool_calls=tool_calls if tool_calls else None,
-            stop_reason=resp.stop_reason,
-            usage=_responses_usage(getattr(resp, "usage", None)),
-        )
-
-
-class AnthropicClient(BaseLLMClient):
-    """Anthropic Claude API client."""
-
-    def __init__(self, api_key: str | None, model: str, base_url: str | None = None):
-        try:
-            from anthropic import Anthropic
-        except ImportError:
-            raise ImportError("anthropic package not installed. Run: pip install anthropic") from None
-
-        kwargs: dict[str, Any] = {"api_key": api_key or os.environ.get("ANTHROPIC_API_KEY", "")}
-        if base_url:
-            kwargs["base_url"] = base_url
-        self.client = Anthropic(**kwargs)  # type: ignore[arg-type]
-        self.model = model
-
-    def chat(
-        self,
-        messages: list[Message],
-        tools: list[Message] | None = None,
-        stream_callback: Any | None = None,
-        **kwargs,
-    ) -> LLMResponse:
-        # Convert OpenAI format to Anthropic format
-        system_prompt = None
-        anthropic_messages = []
-
-        for msg in messages:
-            role = msg["role"]
-            content = msg.get("content", "")
-
-            if role == "system":
-                system_prompt = content
-            elif role == "user":
-                anthropic_messages.append({"role": "user", "content": content})
-            elif role == "assistant":
-                if msg.get("tool_calls"):
-                    blocks = []
-                    if content:
-                        blocks.append({"type": "text", "text": content})
-                    for tc in msg["tool_calls"]:
-                        blocks.append(
-                            {
-                                "type": "tool_use",
-                                "id": tc["id"],
-                                "name": tc["function"]["name"],
-                                "input": json.loads(tc["function"]["arguments"] or "{}"),
-                            }
-                        )
-                    anthropic_messages.append({"role": "assistant", "content": blocks})
-                else:
-                    anthropic_messages.append({"role": "assistant", "content": content})
-            elif role == "tool":
-                anthropic_messages.append(
+        for item in _response_field(resp, "output", []):
+            if _response_field(item, "type") == "message":
+                for block in _response_field(item, "content", []):
+                    if _response_field(block, "type") == "output_text":
+                        content_parts.append(_response_field(block, "text", ""))
+            elif _response_field(item, "type") == "function_call":
+                tool_calls.append(
                     {
-                        "role": "user",
-                        "content": [
-                            {"type": "tool_result", "tool_use_id": msg.get("tool_call_id"), "content": content}
-                        ],
+                        "id": _response_field(item, "call_id"),
+                        "name": _response_field(item, "name"),
+                        "arguments": _response_field(item, "arguments", "{}"),
                     }
                 )
 
-        # Convert tools to Anthropic format
-        anthropic_tools = None
-        if tools:
-            anthropic_tools = [
-                {
-                    "name": t["function"]["name"],
-                    "description": t["function"].get("description", ""),
-                    "input_schema": t["function"].get("parameters", {"type": "object", "properties": {}}),
-                }
-                for t in tools
-            ]
-
-        params = {"model": self.model, "messages": anthropic_messages, "max_tokens": kwargs.get("max_tokens", 4096)}
-        if system_prompt:
-            params["system"] = system_prompt
-        if anthropic_tools:
-            params["tools"] = anthropic_tools
-
-        resp = self.client.messages.create(**params)
-
-        content_parts = []
-        tool_calls = []
-        thinking_parts = []
-
-        for block in resp.content:
-            if block.type == "text":
-                content_parts.append(block.text)
-            elif block.type == "thinking":
-                # Anthropic extended thinking block
-                thinking_parts.append(getattr(block, "thinking", ""))
-            elif block.type == "tool_use":
-                tool_calls.append({"id": block.id, "name": block.name, "arguments": json.dumps(block.input)})
-
         return LLMResponse(
             content="\n".join(content_parts) if content_parts else None,
             tool_calls=tool_calls if tool_calls else None,
-            stop_reason=resp.stop_reason,
-            thinking="\n".join(thinking_parts) if thinking_parts else None,
-            usage=_anthropic_usage(getattr(resp, "usage", None)),
+            stop_reason=_response_field(resp, "stop_reason") or _response_field(resp, "status"),
+            usage=_responses_usage(_response_field(resp, "usage")),
         )
 
 
 def create_llm_client(cfg: ChatConfig | None) -> BaseLLMClient:
-    """Create appropriate LLM client based on config.
+    """Create an any-llm client based on config.
 
     api_type options:
-    - "openai" (default): OpenAI Chat Completions API
+    - Any any-llm provider ID, such as "openai", "anthropic", or "gmi"
     - "openai_responses": OpenAI Responses API
-    - "anthropic": Anthropic Claude API
     """
     api_type = (cfg.api_type if cfg else None) or os.environ.get("AMCP_API_TYPE", "openai")
     model = (cfg.model if cfg else None) or "gpt-4o"
 
-    if api_type == "anthropic":
-        api_key = (cfg.api_key if cfg else None) or os.environ.get("ANTHROPIC_API_KEY")
-        base_url = cfg.base_url if cfg else None
-        return AnthropicClient(api_key=api_key, model=model, base_url=base_url)
-    elif api_type == "openai_responses":
-        base_url = (cfg.base_url if cfg else None) or os.environ.get("AMCP_OPENAI_BASE", "https://api.openai.com/v1")
+    if api_type == "openai_responses":
+        responses_base_url = (cfg.base_url if cfg else None) or os.environ.get(
+            "AMCP_OPENAI_BASE", "https://api.openai.com/v1"
+        )
+        if not responses_base_url.endswith("/v1"):
+            responses_base_url = responses_base_url.rstrip("/") + "/v1"
+        api_key = (cfg.api_key if cfg else None) or os.environ.get("OPENAI_API_KEY")
+        return OpenAIResponsesClient(
+            base_url=responses_base_url,
+            api_key=api_key,
+            model=model,
+        )
+
+    base_url: str | None = cfg.base_url if cfg else None
+    if api_type == "openai":
+        base_url = base_url or os.environ.get("AMCP_OPENAI_BASE", "https://api.openai.com/v1")
         if not base_url.endswith("/v1"):
             base_url = base_url.rstrip("/") + "/v1"
-        api_key = (cfg.api_key if cfg else None) or os.environ.get("OPENAI_API_KEY")
-        return OpenAIResponsesClient(base_url=base_url, api_key=api_key, model=model)
-    else:
-        # Default: OpenAI Chat Completions
-        base_url = (cfg.base_url if cfg else None) or os.environ.get("AMCP_OPENAI_BASE", "https://api.openai.com/v1")
-        if not base_url.endswith("/v1"):
-            base_url = base_url.rstrip("/") + "/v1"
-        api_key = (cfg.api_key if cfg else None) or os.environ.get("OPENAI_API_KEY")
+    api_key = cfg.api_key if cfg else None
+    if api_type == "openai":
+        api_key = api_key or os.environ.get("OPENAI_API_KEY")
+    elif api_type == "gmi":
+        api_key = api_key or os.environ.get("GMI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+
+    if api_type == "openai":
+        assert base_url is not None
         return OpenAIClient(base_url=base_url, api_key=api_key, model=model)
+    if api_type == "anthropic":
+        return AnthropicClient(base_url=base_url, api_key=api_key, model=model)
+    return AnyLLMClient(
+        provider=api_type,
+        base_url=base_url,
+        api_key=api_key,
+        model=model,
+    )

--- a/src/amcp/memory_dream.py
+++ b/src/amcp/memory_dream.py
@@ -9,8 +9,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .chat import _make_client, _resolve_api_key, _resolve_base_url
 from .config import load_config
+from .llm import create_llm_client
 from .memory import MemoryStore, get_memory_manager
 
 logger = logging.getLogger(__name__)
@@ -149,9 +149,7 @@ class MemoryDreamer:
 
     def _make_client(self) -> Any:
         cfg = load_config()
-        base_url = _resolve_base_url(None, cfg.chat)
-        api_key = _resolve_api_key(None, cfg.chat)
-        return _make_client(base_url, api_key)
+        return create_llm_client(cfg.chat)
 
     def _resolve_model(self) -> str:
         cfg = load_config()

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -41,12 +41,16 @@ class TestResolveApiKey:
 
 class TestMakeClient:
     def test_creates_client(self):
-        with patch("builtins.__import__") as mock_import:
-            mock_openai = MagicMock()
-            mock_import.return_value = MagicMock(OpenAI=mock_openai)
-            _make_client("https://api.example.com/v1", "test-key")
-            mock_openai.assert_called_once_with(
+        with patch("amcp.chat.AnyLLMClient") as client_cls:
+            _make_client(
                 base_url="https://api.example.com/v1",
                 api_key="test-key",
-                default_headers={"User-Agent": "AMCPAgent"},
+                provider="gmi",
+                model="test-model",
+            )
+            client_cls.assert_called_once_with(
+                provider="gmi",
+                base_url="https://api.example.com/v1",
+                api_key="test-key",
+                model="test-model",
             )

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -212,13 +212,12 @@ class TestSmartCompactor:
 
     @pytest.fixture
     def mock_client(self):
-        """Create a mock OpenAI client."""
+        """Create a mock AMCP LLM client."""
         client = MagicMock()
         # Mock successful completion response
         mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Compacted summary of the conversation."
-        client.chat.completions.create.return_value = mock_response
+        mock_response.content = "Compacted summary of the conversation."
+        client.chat.return_value = mock_response
         return client
 
     def test_init_calculates_thresholds(self, mock_client):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,6 +65,7 @@ def test_default_chat_uses_gmi_without_api_key():
     assert cfg.active_provider == "gmi"
     assert cfg.base_url == "https://api.gmi-serving.com/v1"
     assert cfg.model == "openai/gpt-5.5"
+    assert cfg.api_type == "gmi"
     assert cfg.api_key is None
     assert "gmi" in cfg.providers
     assert cfg.providers["gmi"].api_key is None
@@ -118,6 +119,28 @@ def test_decode_chat_active_provider_applies_profile():
     assert "model" not in encoded
     assert "api_type" not in encoded
     assert "model_config" not in encoded
+
+
+def test_active_provider_reuses_key_for_same_base_url():
+    cfg = config_module._decode_chat(
+        {
+            "active_provider": "second-model",
+            "providers": {
+                "credential-source": {
+                    "base_url": "https://provider.example/v1",
+                    "model": "first-model",
+                    "api_key": "shared-key",
+                },
+                "second-model": {
+                    "base_url": "https://provider.example/v1",
+                    "model": "second-model",
+                },
+            },
+        }
+    )
+
+    assert cfg is not None
+    assert cfg.api_key == "shared-key"
 
 
 def test_decode_encode_server_config_roundtrip():

--- a/tests/test_init_wizard.py
+++ b/tests/test_init_wizard.py
@@ -1,0 +1,11 @@
+"""Tests for interactive initialization configuration choices."""
+
+from amcp.init_wizard import _resolve_api_type
+
+
+def test_resolve_api_type_uses_supported_any_llm_provider():
+    assert _resolve_api_type("gmi", is_custom=False) == "gmi"
+
+
+def test_resolve_api_type_keeps_custom_provider_openai_compatible():
+    assert _resolve_api_type("custom", is_custom=True) == "openai"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -3,9 +3,17 @@
 from types import SimpleNamespace
 
 import pytest
+from any_llm.types.completion import Reasoning
 
 from amcp.config import ChatConfig
-from amcp.llm import AnthropicClient, LLMResponse, OpenAIClient, OpenAIResponsesClient, create_llm_client
+from amcp.llm import (
+    AnthropicClient,
+    AnyLLMClient,
+    LLMResponse,
+    OpenAIClient,
+    OpenAIResponsesClient,
+    create_llm_client,
+)
 
 
 class TestLLMResponse:
@@ -41,12 +49,15 @@ class TestCreateLLMClient:
         assert isinstance(client, OpenAIResponsesClient)
 
     def test_anthropic_type(self):
-        try:
-            cfg = ChatConfig(api_type="anthropic", model="claude-sonnet-4-20250514", api_key="test-key")
-            client = create_llm_client(cfg)
-            assert isinstance(client, AnthropicClient)
-        except ImportError:
-            pytest.skip("anthropic package not installed")
+        cfg = ChatConfig(api_type="anthropic", model="claude-sonnet-4-20250514", api_key="test-key")
+        client = create_llm_client(cfg)
+        assert isinstance(client, AnthropicClient)
+
+    def test_any_llm_provider_type(self):
+        cfg = ChatConfig(api_type="gmi", model="zai-org/GLM-5.2-FP8", api_key="test-key")
+        client = create_llm_client(cfg)
+        assert isinstance(client, AnyLLMClient)
+        assert client.provider == "gmi"
 
     def test_none_config_uses_defaults(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
@@ -63,7 +74,7 @@ class TestOpenAIClient:
 
     def test_chat_captures_provider_usage(self):
         client = OpenAIClient(base_url="https://api.openai.com/v1", api_key="test-key", model="gpt-4o")
-        client.client.chat.completions.create = lambda **_kwargs: SimpleNamespace(
+        client.client.completion = lambda **_kwargs: SimpleNamespace(
             choices=[
                 SimpleNamespace(
                     message=SimpleNamespace(content="done", tool_calls=None),
@@ -89,12 +100,12 @@ class TestOpenAIClient:
 
     def test_chat_uses_reasoning_as_content_when_content_missing(self):
         client = OpenAIClient(base_url="https://api.openai.com/v1", api_key="test-key", model="gpt-4o")
-        client.client.chat.completions.create = lambda **_kwargs: SimpleNamespace(
+        client.client.completion = lambda **_kwargs: SimpleNamespace(
             choices=[
                 SimpleNamespace(
                     message=SimpleNamespace(
                         content="",
-                        reasoning_content="DeepSeek final answer",
+                        reasoning=Reasoning(content="DeepSeek final answer"),
                         tool_calls=None,
                     ),
                     finish_reason="stop",
@@ -110,12 +121,12 @@ class TestOpenAIClient:
 
     def test_chat_keeps_reasoning_hidden_when_content_present(self):
         client = OpenAIClient(base_url="https://api.openai.com/v1", api_key="test-key", model="gpt-4o")
-        client.client.chat.completions.create = lambda **_kwargs: SimpleNamespace(
+        client.client.completion = lambda **_kwargs: SimpleNamespace(
             choices=[
                 SimpleNamespace(
                     message=SimpleNamespace(
                         content="Visible answer",
-                        reasoning_content="Hidden reasoning",
+                        reasoning=Reasoning(content="Hidden reasoning"),
                         tool_calls=None,
                     ),
                     finish_reason="stop",
@@ -131,34 +142,36 @@ class TestOpenAIClient:
 
     def test_streaming_chat_uses_reasoning_as_content_when_content_missing(self):
         client = OpenAIClient(base_url="https://api.openai.com/v1", api_key="test-key", model="gpt-4o")
-        client.client.chat.completions.create = lambda **_kwargs: [
-            SimpleNamespace(
-                choices=[
-                    SimpleNamespace(
-                        delta=SimpleNamespace(
-                            content=None,
-                            reasoning_content="Deep",
-                            tool_calls=None,
-                        ),
-                        finish_reason=None,
-                    )
-                ],
-                usage=None,
-            ),
-            SimpleNamespace(
-                choices=[
-                    SimpleNamespace(
-                        delta=SimpleNamespace(
-                            content=None,
-                            reasoning_content="Seek",
-                            tool_calls=None,
-                        ),
-                        finish_reason="stop",
-                    )
-                ],
-                usage=None,
-            ),
-        ]
+        client.client.completion = lambda **_kwargs: iter(
+            [
+                SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            delta=SimpleNamespace(
+                                content=None,
+                                reasoning=Reasoning(content="Deep"),
+                                tool_calls=None,
+                            ),
+                            finish_reason=None,
+                        )
+                    ],
+                    usage=None,
+                ),
+                SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            delta=SimpleNamespace(
+                                content=None,
+                                reasoning=Reasoning(content="Seek"),
+                                tool_calls=None,
+                            ),
+                            finish_reason="stop",
+                        )
+                    ],
+                    usage=None,
+                ),
+            ]
+        )
         streamed_chunks = []
 
         response = client.chat(
@@ -172,7 +185,7 @@ class TestOpenAIClient:
 
     def test_chat_raises_clear_error_when_choices_missing(self):
         client = OpenAIClient(base_url="https://api.openai.com/v1", api_key="test-key", model="gpt-4o")
-        client.client.chat.completions.create = lambda **_kwargs: SimpleNamespace(
+        client.client.completion = lambda **_kwargs: SimpleNamespace(
             choices=None,
             usage=None,
         )
@@ -188,7 +201,7 @@ class TestOpenAIResponsesClient:
 
     def test_responses_captures_provider_usage(self):
         client = OpenAIResponsesClient(base_url="https://api.openai.com/v1", api_key="test-key", model="gpt-4o")
-        client.client.responses.create = lambda **_kwargs: SimpleNamespace(
+        client.client.responses = lambda **_kwargs: SimpleNamespace(
             output=[],
             stop_reason="stop",
             usage=SimpleNamespace(
@@ -207,38 +220,101 @@ class TestOpenAIResponsesClient:
         assert response.usage.output_tokens == 50
         assert response.usage.cached_input_tokens == 80
 
+    def test_responses_converts_tool_history(self):
+        messages = [
+            {"role": "user", "content": "read it"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path":"a.py"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "content": "contents"},
+        ]
+
+        converted = OpenAIResponsesClient._convert_messages(messages)
+
+        assert converted == [
+            {"role": "user", "content": "read it"},
+            {
+                "type": "function_call",
+                "call_id": "call-1",
+                "name": "read_file",
+                "arguments": '{"path":"a.py"}',
+            },
+            {"type": "function_call_output", "call_id": "call-1", "output": "contents"},
+        ]
+
+    def test_responses_streams_and_forwards_options(self):
+        client = OpenAIResponsesClient.__new__(OpenAIResponsesClient)
+        client.model = "gpt-4o"
+        captured = {}
+        completed = SimpleNamespace(output=[], status="completed", usage=None)
+
+        def responses(**kwargs):
+            captured.update(kwargs)
+            return iter(
+                [
+                    SimpleNamespace(type="response.output_text.delta", delta="done"),
+                    SimpleNamespace(type="response.completed", response=completed),
+                ]
+            )
+
+        client.client = SimpleNamespace(responses=responses)
+        chunks = []
+
+        response = client.chat(
+            [{"role": "user", "content": "hello"}],
+            stream_callback=chunks.append,
+            model="gpt-5",
+            max_tokens=123,
+            temperature=0.2,
+        )
+
+        assert chunks == ["done"]
+        assert response.stop_reason == "completed"
+        assert captured["model"] == "gpt-5"
+        assert captured["max_output_tokens"] == 123
+        assert captured["temperature"] == 0.2
+        assert captured["stream"] is True
+        assert captured["allow_running_loop"] is True
+
 
 class TestAnthropicClient:
     def test_client_creation(self):
-        try:
-            client = AnthropicClient(api_key="test-key", model="claude-sonnet-4-20250514")
-            assert client.model == "claude-sonnet-4-20250514"
-        except ImportError:
-            pytest.skip("anthropic package not installed")
+        client = AnthropicClient(api_key="test-key", model="claude-sonnet-4-20250514")
+        assert client.model == "claude-sonnet-4-20250514"
 
-    def test_anthropic_captures_provider_usage(self):
+    def test_anthropic_uses_normalized_any_llm_usage(self):
         client = AnthropicClient.__new__(AnthropicClient)
         client.model = "claude-sonnet-4-20250514"
+        client.provider = "anthropic"
         client.client = SimpleNamespace(
-            messages=SimpleNamespace(
-                create=lambda **_kwargs: SimpleNamespace(
-                    content=[],
-                    stop_reason="end_turn",
-                    usage=SimpleNamespace(
-                        input_tokens=100,
-                        output_tokens=20,
-                        cache_creation_input_tokens=10,
-                        cache_read_input_tokens=30,
-                    ),
-                )
+            completion=lambda **_kwargs: SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content="done", tool_calls=None),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=SimpleNamespace(
+                    prompt_tokens=140,
+                    completion_tokens=20,
+                    total_tokens=160,
+                    prompt_tokens_details=SimpleNamespace(cached_tokens=30),
+                ),
             )
         )
 
         response = client.chat([{"role": "user", "content": "hello"}])
 
         assert response.usage is not None
-        assert response.usage.input_tokens == 100
+        assert response.usage.input_tokens == 110
         assert response.usage.prompt_tokens == 140
         assert response.usage.output_tokens == 20
         assert response.usage.cached_input_tokens == 30
-        assert response.usage.cache_write_input_tokens == 10

--- a/uv.lock
+++ b/uv.lock
@@ -24,10 +24,10 @@ version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
+    { name = "any-llm-sdk" },
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "httpx" },
-    { name = "openai" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -39,11 +39,7 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-anthropic = [
-    { name = "anthropic" },
-]
 dev = [
-    { name = "anthropic" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -62,14 +58,12 @@ telegram = [
 [package.metadata]
 requires-dist = [
     { name = "agent-client-protocol", specifier = ">=0.7.0" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.40.0" },
-    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.40.0" },
+    { name = "any-llm-sdk", specifier = ">=1.21.0,<2" },
     { name = "croniter", marker = "extra == 'telegram'", specifier = ">=1.3.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastmcp", specifier = ">=2.0.0,<3" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
-    { name = "openai", specifier = ">=1.52.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.0" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -110,7 +104,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.75.0"
+version = "0.117.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -122,9 +116,27 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/1f/08e95f4b7e2d35205ae5dcbb4ae97e7d477fc521c275c02609e2931ece2d/anthropic-0.75.0.tar.gz", hash = "sha256:e8607422f4ab616db2ea5baacc215dd5f028da99ce2f022e33c7c535b29f3dfb", size = 439565, upload-time = "2025-11-24T20:41:45.28Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/0d/8f71d535edb0d438f023bd825fb65f67c14fa88a2bd6b75f292a58a63de4/anthropic-0.117.0.tar.gz", hash = "sha256:98107f2b76439641e0ae2a1754087534b8f178dbab99d6eb1bc4b7bc8c744496", size = 989933, upload-time = "2026-07-16T19:36:13.07Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/1c/1cd02b7ae64302a6e06724bf80a96401d5313708651d277b1458504a1730/anthropic-0.75.0-py3-none-any.whl", hash = "sha256:ea8317271b6c15d80225a9f3c670152746e88805a7a61e14d4a374577164965b", size = 388164, upload-time = "2025-11-24T20:41:43.587Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4c/917d21d6619a4475cdafc6d13a69fdb3b901ddac57e76caca5a25c117b6d/anthropic-0.117.0-py3-none-any.whl", hash = "sha256:451a0a6905f11dff7663d13e4ee5dbf909eb8942b1d049803c7b937a13ac47ec", size = 998327, upload-time = "2026-07-16T19:36:11.225Z" },
+]
+
+[[package]]
+name = "any-llm-sdk"
+version = "1.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "httpx" },
+    { name = "openai" },
+    { name = "openresponses-types" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/f5/055dd5458d38fd77521b6f555468ef2ec656ebbbf81a59e21fd48e46fac3/any_llm_sdk-1.21.0.tar.gz", hash = "sha256:15fee01e543014245557d86a848e836a7d7cbbf67638eb626c181cfabef92017", size = 162165, upload-time = "2026-07-16T14:59:27.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/cb/4140aa7f43e7ca6a6429ef5b50f3db7a2cbedb8ebe6eeb26780a161cb116/any_llm_sdk-1.21.0-py3-none-any.whl", hash = "sha256:793ce8a52d074a85ca6f393f07f1a5a7f2c6e473c8cf3d5e09b06286ae0c0928", size = 213440, upload-time = "2026-07-16T14:59:26.022Z" },
 ]
 
 [[package]]
@@ -1214,6 +1226,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "openresponses-types"
+version = "2.3.0.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/26/b612c3215f5599714fa94d63eb5ee59b4eb66dbdeeaf86bb4d848359484d/openresponses_types-2.3.0.post1.tar.gz", hash = "sha256:11b8896d3621d2ac2439f6ff106f34ddcb1bbd517c317a6c852a9df2e98a0753", size = 19254, upload-time = "2026-01-22T20:02:03.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/5f/e16dad89ed24f586da5b01b9b206d3adbf21fe1af8e4dc55d5b93158fde6/openresponses_types-2.3.0.post1-py3-none-any.whl", hash = "sha256:88f6abcef9cad839203abff420dd080978bf6eb33cc06ddc5d78da4ccdba7613", size = 13847, upload-time = "2026-01-22T20:02:02.582Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull Request

## Description

Migrate AMCP's LLM client layer from direct OpenAI and Anthropic SDK usage to
`any-llm-sdk>=1.21.0`.

- Route OpenAI Chat Completions, Anthropic, GMI, and other supported providers through any-llm.
- Preserve the dedicated OpenAI Responses adapter while using any-llm as its transport.
- Normalize streaming, tool calls, reasoning content, response usage, compaction, and memory calls.
- Let provider profiles sharing the same endpoint reuse a configured API key.
- Configure providers selected by `amcp init` with their native any-llm provider ID when supported,
  while retaining OpenAI compatibility for custom endpoints.
- Keep provider handling generic; no GPT-5.6 Sol or other model-specific workaround is included.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Testing

```bash
uv run ruff format --check src tests
uv run ruff check src tests
uv run pytest -q -m "not llm"
git diff --check
uv lock --check
```

Result: 773 tests passed.

Live AMCP smoke tests were also run in tmux against these GMI models, with one read-only tool call
and two LLM requests per model to limit cost:

- `zai-org/GLM-5.2-FP8`
- `deepseek-ai/DeepSeek-V4-Pro`
- `moonshotai/kimi-k3`
- `anthropic/claude-sonnet-5`

All four completed the tool round trip and exited successfully.

## Related Issues

N/A
