### PR TITLE
refactor: require v2 session schema

### DIFF
--- a/src/amcp/agent.py
+++ b/src/amcp/agent.py
@@ -191,17 +191,7 @@ class Agent:
 
     def _save_conversation_history(self) -> None:
         """Save the current canonical state, propagating commit failures."""
-        if self.conversation_history != self._session_state.messages:
-            candidate = SessionState.migrate_legacy(
-                {
-                    "agent_name": self.name,
-                    "created_at": self._session_state.created_at,
-                    "conversation_history": self.conversation_history,
-                },
-                self.session_id,
-            )
-        else:
-            candidate = self._session_state.clone()
+        candidate = self._session_state.clone()
         candidate = self._capture_session_state(candidate)
         self._session_store.save(candidate.to_snapshot())
         self._session_state = candidate
@@ -209,7 +199,6 @@ class Agent:
 
     def _capture_session_state(self, state: SessionState) -> SessionState:
         """Copy compatibility attributes into one candidate session state."""
-        state.messages = deepcopy(self.conversation_history)
         state.tool_calls_history = deepcopy(self.tool_calls_history)
         state.current_conversation_tool_calls = deepcopy(self.current_conversation_tool_calls)
         state.usage.total_llm_calls = self.total_llm_calls

--- a/src/amcp/session_state.py
+++ b/src/amcp/session_state.py
@@ -20,7 +20,6 @@ class CanonicalTurn:
     start_message: int
     end_message: int
     completed_at: str
-    legacy: bool = False
 
 
 @dataclass
@@ -154,54 +153,6 @@ class SessionState:
         validate_session_state(state)
         return state
 
-    @classmethod
-    def migrate_legacy(cls, data: dict[str, Any], session_id: str) -> SessionState:
-        """Migrate v0/v1 user/assistant history without inventing tool evidence."""
-        messages = data.get("conversation_history", [])
-        if not isinstance(messages, list):
-            raise InvalidSessionStateError("Legacy conversation_history must be a list")
-        copied = deepcopy(messages)
-        for message in copied:
-            if not isinstance(message, dict) or message.get("role") not in {
-                "user",
-                "assistant",
-            }:
-                raise InvalidSessionStateError("Legacy history may contain only user and assistant messages")
-
-        turns: list[CanonicalTurn] = []
-        start = 0
-        while start < len(copied):
-            end = start + 1
-            if copied[start].get("role") == "user":
-                while end < len(copied) and copied[end].get("role") != "user":
-                    end += 1
-            turns.append(
-                CanonicalTurn(
-                    turn_id=f"legacy-{len(turns) + 1}",
-                    start_message=start,
-                    end_message=end,
-                    completed_at=str(data.get("created_at", datetime.now().isoformat())),
-                    legacy=True,
-                )
-            )
-            start = end
-
-        usage_fields = SessionUsage.__dataclass_fields__
-        usage = SessionUsage(**{name: data[name] for name in usage_fields if name in data})
-        state = cls(
-            session_id=session_id,
-            agent_name=str(data.get("agent_name", "default")),
-            created_at=str(data.get("created_at", datetime.now().isoformat())),
-            messages=copied,
-            turns=turns,
-            usage=usage,
-            tool_calls_history=deepcopy(data.get("tool_calls_history", [])),
-            current_conversation_tool_calls=deepcopy(data.get("current_conversation_tool_calls", [])),
-            last_memory_review_turn_count=int(data.get("last_memory_review_turn_count", 0)),
-        )
-        validate_session_state(state)
-        return state
-
 
 def validate_session_state(state: SessionState) -> None:
     """Validate turn ranges, tool batches, and checkpoint coverage."""
@@ -210,8 +161,14 @@ def validate_session_state(state: SessionState) -> None:
     expected_start = 0
     turn_ids: set[str] = set()
     for turn in state.turns:
-        if not turn.turn_id or turn.turn_id in turn_ids:
+        if not isinstance(turn.turn_id, str) or not turn.turn_id or turn.turn_id in turn_ids:
             raise InvalidSessionStateError("Committed turn IDs must be unique")
+        if (
+            type(turn.start_message) is not int
+            or type(turn.end_message) is not int
+            or not isinstance(turn.completed_at, str)
+        ):
+            raise InvalidSessionStateError("Committed turn fields have invalid types")
         turn_ids.add(turn.turn_id)
         if (
             turn.start_message != expected_start
@@ -220,10 +177,7 @@ def validate_session_state(state: SessionState) -> None:
         ):
             raise InvalidSessionStateError("Session turn ranges must be contiguous and valid")
         turn_messages = state.messages[turn.start_message : turn.end_message]
-        if turn.legacy:
-            _validate_legacy_turn(turn_messages)
-        else:
-            _validate_complete_turn(turn_messages)
+        _validate_complete_turn(turn_messages)
         expected_start = turn.end_message
     if expected_start != len(state.messages):
         raise InvalidSessionStateError("Every canonical message must belong to one turn")
@@ -240,6 +194,16 @@ def validate_session_state(state: SessionState) -> None:
         )
     ):
         raise InvalidSessionStateError("Compaction checkpoint context must be a non-empty list")
+    integer_fields = (
+        checkpoint.covered_message_count,
+        checkpoint.covered_turn_count,
+        checkpoint.generation,
+        checkpoint.strategy_version,
+        checkpoint.original_tokens,
+        checkpoint.compacted_tokens,
+    )
+    if any(type(value) is not int for value in integer_fields) or not isinstance(checkpoint.strategy, str):
+        raise InvalidSessionStateError("Compaction checkpoint fields have invalid types")
     if not 0 < checkpoint.covered_turn_count <= len(state.turns):
         raise InvalidSessionStateError("Compaction checkpoint has invalid turn coverage")
     boundary = state.turns[checkpoint.covered_turn_count - 1].end_message
@@ -247,13 +211,6 @@ def validate_session_state(state: SessionState) -> None:
         raise InvalidSessionStateError("Compaction checkpoint coverage must end on a complete turn boundary")
     if checkpoint.generation < 1 or checkpoint.strategy_version < 1:
         raise InvalidSessionStateError("Compaction checkpoint generation is invalid")
-
-
-def _validate_legacy_turn(messages: list[dict[str, Any]]) -> None:
-    if not messages or any(
-        not isinstance(message, dict) or message.get("role") not in {"user", "assistant"} for message in messages
-    ):
-        raise InvalidSessionStateError("Legacy turn contains invalid messages")
 
 
 def _validate_complete_turn(messages: list[dict[str, Any]]) -> None:

--- a/src/amcp/session_store.py
+++ b/src/amcp/session_store.py
@@ -82,16 +82,12 @@ class SessionStore:
 
             if not isinstance(data, dict):
                 raise SessionLoadError(f"Session {self.session_id} must contain a JSON object")
-            version = data.get("schema_version", 0)
-            if not isinstance(version, int) or version < 0 or version > SESSION_SCHEMA_VERSION:
+            version = data.get("schema_version")
+            if version != SESSION_SCHEMA_VERSION or type(version) is not int:
                 raise SessionLoadError(f"Unsupported session schema version {version!r} for {self.session_id}")
             try:
-                state = (
-                    SessionState.from_snapshot(data, self.session_id)
-                    if version == SESSION_SCHEMA_VERSION
-                    else SessionState.migrate_legacy(data, self.session_id)
-                )
-            except InvalidSessionStateError as exc:
+                state = SessionState.from_snapshot(data, self.session_id)
+            except (InvalidSessionStateError, TypeError, ValueError) as exc:
                 raise SessionLoadError(f"Invalid session state for {self.session_id}: {exc}") from exc
             return {
                 **state.to_snapshot(),

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -15,6 +15,7 @@ from amcp.hooks import HookOutput
 from amcp.llm import LLMResponse, TokenUsage
 from amcp.memory import MemoryManager, MemoryStore
 from amcp.multi_agent import AgentMode
+from amcp.session_state import SessionState
 from amcp.session_store import SessionLoadError
 from amcp.tools import create_default_tool_registry
 
@@ -56,12 +57,16 @@ class TestAgentInit:
         sessions_dir = tmp_path / ".config" / "amcp" / "sessions"
         sessions_dir.mkdir(parents=True, exist_ok=True)
         session_file = sessions_dir / "test-session.json"
-        data = {
-            "conversation_history": [{"role": "user", "content": "hi"}],
-            "tool_calls_history": [],
-            "current_conversation_tool_calls": [],
-            "total_llm_calls": 1,
-        }
+        state = SessionState(session_id="test-session", agent_name="default")
+        state.commit_turn(
+            "turn-1",
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ],
+        )
+        state.usage.total_llm_calls = 1
+        data = {**state.to_snapshot(), "schema_version": 2}
         session_file.write_text(json.dumps(data))
 
         with patch("amcp.agent.Path.home") as mock_home:
@@ -69,7 +74,7 @@ class TestAgentInit:
             with patch("amcp.agent.load_config") as mock_load:
                 mock_load.return_value = MagicMock()
                 agent = Agent(session_id="test-session")
-                assert len(agent.conversation_history) == 1
+                assert len(agent.conversation_history) == 2
                 assert agent.total_llm_calls == 1
 
     def test_load_history_handles_corrupted_file(self, tmp_path):
@@ -334,12 +339,22 @@ class TestAgentHistoryManagement:
             with patch("amcp.agent.load_config") as mock_load:
                 mock_load.return_value = MagicMock()
                 agent = Agent(session_id="test-session")
-                agent.conversation_history = [{"role": "user", "content": "hi"}]
+                agent._session_state.commit_turn(
+                    "turn-1",
+                    [
+                        {"role": "user", "content": "hi"},
+                        {"role": "assistant", "content": "hello"},
+                    ],
+                )
+                agent._apply_session_state(agent._session_state)
                 agent._save_conversation_history()
                 assert agent.session_file.exists()
                 data = json.loads(agent.session_file.read_text())
                 assert data["schema_version"] == 2
-                assert data["conversation"]["messages"] == [{"role": "user", "content": "hi"}]
+                assert data["conversation"]["messages"] == [
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "hello"},
+                ]
 
 
 class TestAgentContextBudget:

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -66,33 +66,16 @@ def test_corrupt_session_has_explicit_diagnostic(tmp_path):
         store.load()
 
 
-def test_migrates_v1_history_without_inventing_tool_messages(tmp_path):
-    store = SessionStore(tmp_path, "legacy")
-    store.path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "session_id": "legacy",
-                "agent_name": "default",
-                "conversation_history": [
-                    {"role": "user", "content": "inspect"},
-                    {"role": "assistant", "content": "done"},
-                ],
-                "tool_calls_history": [{"tool": "read_file"}],
-            }
-        ),
-        encoding="utf-8",
-    )
+@pytest.mark.parametrize("schema_version", [None, 0, 1, 3, True])
+def test_rejects_any_schema_other_than_v2(tmp_path, schema_version):
+    store = SessionStore(tmp_path, "unsupported")
+    payload = {"conversation_history": []}
+    if schema_version is not None:
+        payload["schema_version"] = schema_version
+    store.path.write_text(json.dumps(payload), encoding="utf-8")
 
-    data = store.load()
-
-    assert data["schema_version"] == 2
-    assert [message["role"] for message in data["conversation"]["messages"]] == [
-        "user",
-        "assistant",
-    ]
-    assert data["conversation"]["turns"][0]["legacy"] is True
-    assert all(message["role"] != "tool" for message in data["conversation"]["messages"])
+    with pytest.raises(SessionLoadError, match="Unsupported session schema version"):
+        store.load()
 
 
 def test_rejects_broken_tool_batch(tmp_path):
@@ -177,4 +160,41 @@ def test_rejects_checkpoint_inside_a_turn(tmp_path):
     store.path.write_text(json.dumps(raw), encoding="utf-8")
 
     with pytest.raises(SessionLoadError, match="complete turn boundary"):
+        store.load()
+
+
+def test_rejects_checkpoint_with_invalid_field_types(tmp_path):
+    store = SessionStore(tmp_path, "checkpoint-types")
+    state = SessionState(session_id="checkpoint-types", agent_name="default")
+    state.commit_turn(
+        "turn-1",
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ],
+    )
+    raw = {
+        "schema_version": 2,
+        "session_id": "checkpoint-types",
+        "agent_name": "default",
+        "conversation": {
+            "messages": state.messages,
+            "turns": [asdict(state.turns[0])],
+        },
+        "compaction_checkpoint": {
+            "context": [{"role": "assistant", "content": "summary"}],
+            "covered_message_count": 2,
+            "covered_turn_count": "1",
+            "generation": 1,
+            "strategy": "summary",
+            "strategy_version": 1,
+            "original_tokens": 10,
+            "compacted_tokens": 2,
+        },
+        "usage": {},
+        "diagnostics": {},
+    }
+    store.path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(SessionLoadError, match="checkpoint fields have invalid types"):
         store.load()


### PR DESCRIPTION
# Pull Request

## Description

Require the canonical v2 session schema and remove the unused v0/v1 migration path. Session loading now rejects missing or unsupported versions, canonical turns no longer carry legacy state, and malformed checkpoint field types consistently surface as `SessionLoadError`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Testing

```bash
ruff format src tests
ruff check src tests
mypy src/amcp --ignore-missing-imports
python -m pytest -q -m "not llm"
```

## Related Issues

None.
