### PR TITLE
fix: repair and validate model-supplied tool arguments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,9 @@ progressive context management.
 ## Architecture Patterns
 
 - Tools are classes inheriting from `BaseTool` in `src/amcp/tools.py`.
+- Model-supplied tool arguments are repaired and validated against each tool's JSON schema in
+  `src/amcp/tool_schema.py`; register parameter aliases there instead of widening tool
+  signatures, and never let an invalid argument reach `execute()` as a raw `TypeError`.
 - Agents are configured through `AgentSpec` and `ResolvedAgentSpec`.
 - Built-in agent types live in `src/amcp/multi_agent.py`.
 - Configuration is TOML and is loaded through `src/amcp/config.py`.
@@ -67,6 +70,8 @@ src/amcp/
 ├── memory.py             # Memory orchestration
 ├── models_db.py          # Model metadata lookup
 ├── project_rules.py      # AGENTS.md loading
+├── tool_execution.py     # Capability checks and workspace-bound tool dispatch
+├── tool_schema.py        # Tool argument alias repair and schema validation
 ├── client/               # Embedded, HTTP, and WebSocket clients
 ├── protocol/             # HTTP/WebSocket protocol adapters and converters
 ├── server/               # HTTP/WebSocket server

--- a/src/amcp/agent.py
+++ b/src/amcp/agent.py
@@ -57,6 +57,7 @@ from .tool_execution import (
     ToolExecutor,
     normalize_tool_calls,
 )
+from .tool_schema import ToolArgumentError
 from .tools import ToolRegistry
 from .ui import LiveUI
 
@@ -1498,6 +1499,25 @@ class Agent:
                                     "reason": tool_result_text,
                                 },
                             )
+                            append_canonical(
+                                {
+                                    "role": "tool",
+                                    "tool_call_id": tool_id,
+                                    "name": tool_name,
+                                    "content": tool_result_text,
+                                }
+                            )
+                            continue
+
+                        # Hooks must inspect the same canonical arguments that
+                        # execution will use, otherwise an alias such as
+                        # ``cmd`` could bypass a rule matching ``command``.
+                        try:
+                            args = executor.prepare_arguments(tool_name, args)
+                        except ToolArgumentError as exc:
+                            tool_result_text = f"Error: Invalid arguments: {exc}"
+                            block = live_ui.add_tool(tool_name, args)
+                            live_ui.finish_tool(block, success=False, result=tool_result_text)
                             append_canonical(
                                 {
                                     "role": "tool",

--- a/src/amcp/server/routes/tools.py
+++ b/src/amcp/server/routes/tools.py
@@ -97,7 +97,9 @@ async def execute_tool(tool_name: str, arguments: dict[str, Any]) -> dict:
         )
 
     try:
-        result = tool_func.execute(**arguments)
+        # Go through the registry so arguments are validated the same way as
+        # agent-driven calls instead of raising a raw TypeError.
+        result = tool_registry.execute_tool(tool_name, **arguments)
 
         if isinstance(result, ToolResult):
             return {

--- a/src/amcp/server/routes/tools.py
+++ b/src/amcp/server/routes/tools.py
@@ -85,6 +85,7 @@ async def execute_tool(tool_name: str, arguments: dict[str, Any]) -> dict:
 
     Warning: This bypasses normal safety checks.
     """
+    from ...tool_schema import ToolArgumentError
     from ...tools import ToolResult, get_tool_registry
 
     tool_registry = get_tool_registry()
@@ -97,8 +98,9 @@ async def execute_tool(tool_name: str, arguments: dict[str, Any]) -> dict:
         )
 
     try:
-        # Go through the registry so arguments are validated the same way as
-        # agent-driven calls instead of raising a raw TypeError.
+        # This endpoint accepts untrusted model-shaped input, so repair and
+        # validate it before dispatch just like the agent execution path.
+        arguments = tool_registry.prepare_arguments(tool_name, arguments)
         result = tool_registry.execute_tool(tool_name, **arguments)
 
         if isinstance(result, ToolResult):
@@ -114,6 +116,12 @@ async def execute_tool(tool_name: str, arguments: dict[str, Any]) -> dict:
                 "error": None,
             }
 
+    except ToolArgumentError as e:
+        return {
+            "success": False,
+            "result": None,
+            "error": f"Invalid arguments: {e}",
+        }
     except Exception as e:
         return {
             "success": False,

--- a/src/amcp/tool_execution.py
+++ b/src/amcp/tool_execution.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from .config import AMCPConfig
 from .mcp_client import call_mcp_tool
-from .tool_schema import ToolArgumentError, normalize_tool_arguments
+from .tool_schema import ToolArgumentError
 from .tools import ToolRegistry, ToolResult
 
 
@@ -177,7 +177,7 @@ class ToolExecutor:
             raise ToolPermissionError(f"Tool '{name}' is not authorized for this turn")
 
         try:
-            arguments = self._normalize_arguments(name, arguments)
+            arguments = self.prepare_arguments(name, arguments)
         except ToolArgumentError as exc:
             return ToolResult(success=False, content="", error=f"Invalid arguments: {exc}")
 
@@ -193,19 +193,17 @@ class ToolExecutor:
             return await self._execute_bash(args)
         return await asyncio.to_thread(self.registry.execute_tool, name, **args)
 
-    def _normalize_arguments(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    def prepare_arguments(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         """Repair near-miss model arguments against the tool's published schema.
 
-        This runs before argument binding so alias repair (``path`` -> ``paths``)
-        happens before trusted runtime values are injected. MCP tools own their
-        own schemas remotely, so they are passed through untouched.
+        Callers that run safety hooks must use the returned canonical arguments
+        as hook input. Execution repeats this step after hooks have applied any
+        updates and before trusted runtime values are injected. MCP tools own
+        their schemas remotely, so they are passed through untouched.
         """
         if name.startswith("mcp."):
             return dict(arguments)
-        tool = self.registry.get_tool(name)
-        if tool is None:
-            return dict(arguments)
-        return normalize_tool_arguments(name, tool.get_parameters_schema(), arguments)
+        return self.registry.prepare_arguments(name, arguments)
 
     def _bind_arguments(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         args = dict(arguments)

--- a/src/amcp/tool_execution.py
+++ b/src/amcp/tool_execution.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from .config import AMCPConfig
 from .mcp_client import call_mcp_tool
+from .tool_schema import ToolArgumentError, normalize_tool_arguments
 from .tools import ToolRegistry, ToolResult
 
 
@@ -175,6 +176,11 @@ class ToolExecutor:
         if name not in self.exposed_tools or not self.capability.allows(name):
             raise ToolPermissionError(f"Tool '{name}' is not authorized for this turn")
 
+        try:
+            arguments = self._normalize_arguments(name, arguments)
+        except ToolArgumentError as exc:
+            return ToolResult(success=False, content="", error=f"Invalid arguments: {exc}")
+
         args = self._bind_arguments(name, arguments)
         if name.startswith("mcp."):
             return await self._execute_mcp(name, args)
@@ -186,6 +192,20 @@ class ToolExecutor:
         if name == "bash":
             return await self._execute_bash(args)
         return await asyncio.to_thread(self.registry.execute_tool, name, **args)
+
+    def _normalize_arguments(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Repair near-miss model arguments against the tool's published schema.
+
+        This runs before argument binding so alias repair (``path`` -> ``paths``)
+        happens before trusted runtime values are injected. MCP tools own their
+        own schemas remotely, so they are passed through untouched.
+        """
+        if name.startswith("mcp."):
+            return dict(arguments)
+        tool = self.registry.get_tool(name)
+        if tool is None:
+            return dict(arguments)
+        return normalize_tool_arguments(name, tool.get_parameters_schema(), arguments)
 
     def _bind_arguments(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         args = dict(arguments)

--- a/src/amcp/tool_schema.py
+++ b/src/amcp/tool_schema.py
@@ -1,0 +1,435 @@
+"""Repair and validation for model-supplied tool arguments.
+
+Model providers frequently emit near-miss parameter names (``path`` instead of
+``paths``) or scalars where arrays are expected. Passing those straight into a
+tool's ``execute`` signature raises an opaque ``TypeError``, which costs a turn
+and often pushes the model into abandoning the tool entirely (for example
+falling back to ``bash`` + ``grep``).
+
+This module repairs what can be repaired safely against the tool's published
+JSON schema, and turns everything else into an actionable message the model can
+correct on its next attempt.
+"""
+
+from __future__ import annotations
+
+import difflib
+import inspect
+import json
+from collections.abc import Callable, Mapping
+from typing import Any
+
+__all__ = [
+    "IGNORED_PARAMETERS",
+    "PARAMETER_ALIASES",
+    "ToolArgumentError",
+    "normalize_tool_arguments",
+    "validate_callable_arguments",
+]
+
+
+class ToolArgumentError(Exception):
+    """Raised when tool arguments cannot be repaired into a valid call."""
+
+
+# Frequently hallucinated parameter names mapped to the canonical schema name.
+# Alias keys are matched after case/separator folding, so ``filePath`` and
+# ``file_path`` both resolve through the same entry.
+PARAMETER_ALIASES: dict[str, dict[str, str]] = {
+    "grep": {
+        "path": "paths",
+        "file": "paths",
+        "files": "paths",
+        "dir": "paths",
+        "directory": "paths",
+        "directories": "paths",
+        "search_path": "paths",
+        "search_paths": "paths",
+        "regex": "pattern",
+        "query": "pattern",
+        "search": "pattern",
+        "glob": "globs",
+        "include": "globs",
+        "file_pattern": "globs",
+        "case_insensitive": "ignore_case",
+        "context_lines": "context",
+    },
+    "read_file": {
+        "file_path": "path",
+        "filename": "path",
+        "file": "path",
+        "line_ranges": "ranges",
+        "range": "ranges",
+    },
+    "write_file": {
+        "file_path": "path",
+        "filename": "path",
+        "file": "path",
+        "text": "content",
+        "contents": "content",
+        "data": "content",
+    },
+    "bash": {
+        "cmd": "command",
+        "commands": "command",
+        "script": "command",
+        "shell_command": "command",
+        "timeout_seconds": "timeout",
+    },
+    "apply_patch": {
+        "patch_text": "patch",
+        "patches": "patch",
+        "diff": "patch",
+    },
+    "think": {
+        "thoughts": "thought",
+        "reasoning": "thought",
+        "text": "thought",
+    },
+    "todo": {
+        "todo_list": "todos",
+        "tasks": "todos",
+        "items": "todos",
+    },
+    "task": {
+        "task": "description",
+        "prompt": "description",
+        "type": "agent_type",
+        "id": "task_id",
+    },
+    "memory": {
+        "text": "content",
+        "value": "content",
+        "fact_key": "key",
+        "tag": "tags",
+        "limit": "max_results",
+    },
+    "session_search": {
+        "q": "query",
+        "search": "query",
+        "text": "query",
+        "limit": "max_results",
+    },
+    "web_search": {
+        "q": "query",
+        "search_query": "query",
+        "keywords": "query",
+        "num_results": "limit",
+        "max_results": "limit",
+        "count": "limit",
+    },
+    "web_fetch": {
+        "link": "url",
+        "uri": "url",
+        "max_length": "max_chars",
+        "max_characters": "max_chars",
+    },
+}
+
+# Parameters that are dropped instead of rejected, because the runtime owns them.
+# ``bash`` always runs in the trusted workspace root, so a model-supplied working
+# directory is intentionally ignored rather than treated as a hard error.
+IGNORED_PARAMETERS: dict[str, frozenset[str]] = {
+    "bash": frozenset({"cwd", "workdir", "working_dir", "working_directory"}),
+}
+
+_TRUE_STRINGS = frozenset({"true", "yes", "y", "on", "1"})
+_FALSE_STRINGS = frozenset({"false", "no", "n", "off", "0"})
+
+
+def _fold(name: Any) -> str:
+    """Fold a parameter name so case and separators do not matter."""
+    return "".join(char for char in str(name).lower() if char.isalnum())
+
+
+def _parameter_list(names: object) -> str:
+    """Render a stable, model-friendly list of supported parameter names."""
+    if isinstance(names, Mapping):
+        candidates = list(names.keys())
+    elif isinstance(names, (list, set, frozenset, tuple)):
+        candidates = list(names)
+    else:  # pragma: no cover - defensive
+        candidates = []
+    visible = sorted(str(name) for name in candidates if not str(name).startswith("_"))
+    return ", ".join(visible) if visible else "(none)"
+
+
+def _suggest(name: str, candidates: list[str]) -> str | None:
+    """Return the closest supported parameter name, if there is an obvious one."""
+    close = difflib.get_close_matches(name, candidates, n=1, cutoff=0.5)
+    if close:
+        return close[0]
+    folded = _fold(name)
+    for candidate in candidates:
+        candidate_folded = _fold(candidate)
+        if folded and (candidate_folded.startswith(folded) or folded.startswith(candidate_folded)):
+            return candidate
+    return None
+
+
+def _unsupported_message(tool_name: str, unknown: list[Any], supported: object) -> str:
+    supported_text = _parameter_list(supported)
+    candidates = [part for part in supported_text.split(", ") if part != "(none)"]
+    hints: list[str] = []
+    for raw_name in unknown:
+        name = str(raw_name)
+        suggestion = _suggest(name, candidates)
+        hints.append(f"'{name}'" + (f" (did you mean '{suggestion}'?)" if suggestion else ""))
+    return (
+        f"Tool '{tool_name}' does not support parameter(s): {', '.join(hints)}. Supported parameters: {supported_text}."
+    )
+
+
+def _missing_message(tool_name: str, missing: list[str], supported: object) -> str:
+    return (
+        f"Tool '{tool_name}' is missing required parameter(s): {', '.join(sorted(missing))}. "
+        f"Supported parameters: {_parameter_list(supported)}."
+    )
+
+
+def _type_error(tool_name: str, name: str, expected: str, value: Any) -> ToolArgumentError:
+    return ToolArgumentError(f"Tool '{tool_name}' parameter '{name}' must be {expected} (got {type(value).__name__})")
+
+
+def _item_type(spec: Mapping[str, Any]) -> str | None:
+    items = spec.get("items")
+    if isinstance(items, Mapping):
+        item_type = items.get("type")
+        if isinstance(item_type, str):
+            return item_type
+    return None
+
+
+def _coerce_array(tool_name: str, name: str, spec: Mapping[str, Any], value: Any) -> list[Any]:
+    if isinstance(value, str):
+        text = value.strip()
+        parsed: Any = None
+        if text.startswith("["):
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                parsed = None
+        items = parsed if isinstance(parsed, list) else [value]
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        items = list(value)
+    elif isinstance(value, Mapping):
+        raise _type_error(tool_name, name, "an array", value)
+    else:
+        items = [value]
+
+    if _item_type(spec) != "string":
+        return items
+
+    coerced: list[str] = []
+    for item in items:
+        if isinstance(item, str):
+            coerced.append(item)
+        elif isinstance(item, (int, float)) and not isinstance(item, bool):
+            coerced.append(str(item))
+        else:
+            raise _type_error(tool_name, name, "an array of strings", item)
+    return coerced
+
+
+def _coerce_object(tool_name: str, name: str, value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise _type_error(tool_name, name, "an object", value) from exc
+        if isinstance(parsed, dict):
+            return parsed
+    raise _type_error(tool_name, name, "an object", value)
+
+
+def _coerce_boolean(tool_name: str, name: str, value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in _TRUE_STRINGS:
+            return True
+        if text in _FALSE_STRINGS:
+            return False
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    raise _type_error(tool_name, name, "a boolean", value)
+
+
+def _coerce_integer(tool_name: str, name: str, value: Any) -> int:
+    if isinstance(value, bool):
+        raise _type_error(tool_name, name, "an integer", value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError as exc:
+            raise _type_error(tool_name, name, "an integer", value) from exc
+    raise _type_error(tool_name, name, "an integer", value)
+
+
+def _coerce_number(tool_name: str, name: str, value: Any) -> float | int:
+    if isinstance(value, bool):
+        raise _type_error(tool_name, name, "a number", value)
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError as exc:
+            raise _type_error(tool_name, name, "a number", value) from exc
+    raise _type_error(tool_name, name, "a number", value)
+
+
+def _coerce_string(tool_name: str, name: str, value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(value)
+    raise _type_error(tool_name, name, "a string", value)
+
+
+def _check_bounds(tool_name: str, name: str, spec: Mapping[str, Any], value: Any) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return
+    minimum = spec.get("minimum")
+    maximum = spec.get("maximum")
+    if isinstance(minimum, (int, float)) and value < minimum:
+        raise ToolArgumentError(f"Tool '{tool_name}' parameter '{name}' must be >= {minimum} (got {value})")
+    if isinstance(maximum, (int, float)) and value > maximum:
+        raise ToolArgumentError(f"Tool '{tool_name}' parameter '{name}' must be <= {maximum} (got {value})")
+
+
+def _coerce(tool_name: str, name: str, spec: Mapping[str, Any], value: Any) -> Any:
+    """Coerce one value toward its declared JSON schema type."""
+    if value is None:
+        return None
+
+    expected = spec.get("type")
+    if isinstance(expected, list):
+        expected = next((entry for entry in expected if entry != "null"), None)
+
+    if expected == "array":
+        value = _coerce_array(tool_name, name, spec, value)
+    elif expected == "object":
+        value = _coerce_object(tool_name, name, value)
+    elif expected == "boolean":
+        value = _coerce_boolean(tool_name, name, value)
+    elif expected == "integer":
+        value = _coerce_integer(tool_name, name, value)
+    elif expected == "number":
+        value = _coerce_number(tool_name, name, value)
+    elif expected == "string":
+        value = _coerce_string(tool_name, name, value)
+
+    enum = spec.get("enum")
+    if isinstance(enum, list) and enum and value not in enum:
+        allowed = ", ".join(str(entry) for entry in enum)
+        raise ToolArgumentError(f"Tool '{tool_name}' parameter '{name}' must be one of: {allowed} (got {value!r})")
+
+    _check_bounds(tool_name, name, spec, value)
+    return value
+
+
+def normalize_tool_arguments(
+    tool_name: str,
+    schema: Mapping[str, Any] | None,
+    arguments: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return canonical arguments for a tool, repairing recoverable mistakes.
+
+    Aliases are resolved to their schema name, scalars are widened to arrays,
+    and stringified scalars are coerced to their declared type. Anything that
+    cannot be repaired raises :class:`ToolArgumentError` with a message listing
+    the supported parameters, so the model can fix the call instead of guessing.
+    """
+    if not isinstance(arguments, Mapping):
+        raise ToolArgumentError(f"Arguments for tool '{tool_name}' must be a JSON object")
+
+    schema = schema or {}
+    properties = schema.get("properties")
+    if not isinstance(properties, dict) or not properties:
+        return dict(arguments)
+
+    aliases = {_fold(alias): target for alias, target in PARAMETER_ALIASES.get(tool_name, {}).items()}
+    canonical = {_fold(name): name for name in properties}
+    ignored = {_fold(name) for name in IGNORED_PARAMETERS.get(tool_name, frozenset())}
+
+    resolved: dict[str, Any] = {}
+    unknown: list[Any] = []
+    for raw_name, value in arguments.items():
+        folded = _fold(raw_name)
+        if folded in ignored and folded not in canonical:
+            continue
+        name = canonical.get(folded) or canonical.get(_fold(aliases.get(folded, "")))
+        if name is None:
+            unknown.append(raw_name)
+            continue
+        # Never let an alias shadow an explicitly supplied canonical parameter.
+        if name in resolved and folded != _fold(name):
+            continue
+        resolved[name] = value
+
+    if unknown:
+        if schema.get("additionalProperties") is False:
+            raise ToolArgumentError(_unsupported_message(tool_name, unknown, properties))
+        for raw_name in unknown:
+            resolved.setdefault(str(raw_name), arguments[raw_name])
+
+    normalized: dict[str, Any] = {}
+    for name, value in resolved.items():
+        spec = properties.get(name)
+        normalized[name] = _coerce(tool_name, name, spec if isinstance(spec, Mapping) else {}, value)
+
+    required = schema.get("required")
+    if isinstance(required, list):
+        missing = [str(name) for name in required if normalized.get(str(name)) is None]
+        if missing:
+            raise ToolArgumentError(_missing_message(tool_name, missing, properties))
+
+    return normalized
+
+
+def validate_callable_arguments(
+    tool_name: str,
+    func: Callable[..., Any],
+    arguments: Mapping[str, Any],
+) -> None:
+    """Reject kwargs a tool cannot bind, before they become an opaque TypeError.
+
+    This is the last line of defense for callers that skip
+    :func:`normalize_tool_arguments` (direct registry calls, the HTTP execute
+    endpoint, tests), so an unsupported parameter yields a readable message
+    instead of ``TypeError: execute() got an unexpected keyword argument``.
+    """
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):  # pragma: no cover - builtins without signatures
+        return
+
+    parameters = signature.parameters
+    if any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()):
+        return
+
+    bindable = {
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    }
+    accepted = {name for name, parameter in parameters.items() if parameter.kind in bindable}
+
+    unknown = [name for name in arguments if name not in accepted]
+    if unknown:
+        raise ToolArgumentError(_unsupported_message(tool_name, unknown, accepted))
+
+    missing = [
+        name
+        for name, parameter in parameters.items()
+        if parameter.kind in bindable and parameter.default is inspect.Parameter.empty and name not in arguments
+    ]
+    if missing:
+        raise ToolArgumentError(_missing_message(tool_name, missing, accepted))

--- a/src/amcp/tools.py
+++ b/src/amcp/tools.py
@@ -14,7 +14,11 @@ from typing import Any, Protocol, cast, runtime_checkable
 import httpx
 from rich.console import Console
 
-from .tool_schema import ToolArgumentError, validate_callable_arguments
+from .tool_schema import (
+    ToolArgumentError,
+    normalize_tool_arguments,
+    validate_callable_arguments,
+)
 
 
 @dataclass
@@ -144,6 +148,13 @@ class ToolRegistry:
     def get_tool_specs(self) -> dict[str, dict[str, Any]]:
         """Get all tool specifications."""
         return self._tool_specs.copy()
+
+    def prepare_arguments(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Normalize untrusted arguments against a tool's published schema."""
+        tool = self.get_tool(name)
+        if tool is None:
+            return dict(arguments)
+        return normalize_tool_arguments(name, tool.get_parameters_schema(), arguments)
 
     def execute_tool(self, name: str, **kwargs) -> ToolResult:
         """Execute a tool by name."""

--- a/src/amcp/tools.py
+++ b/src/amcp/tools.py
@@ -14,6 +14,8 @@ from typing import Any, Protocol, cast, runtime_checkable
 import httpx
 from rich.console import Console
 
+from .tool_schema import ToolArgumentError, validate_callable_arguments
+
 
 @dataclass
 class ToolResult:
@@ -150,6 +152,10 @@ class ToolRegistry:
             return ToolResult(success=False, content="", error=f"Tool '{name}' not found")
 
         try:
+            # Reject unbindable arguments up front so callers get an actionable
+            # message instead of an opaque TypeError from execute().
+            validate_callable_arguments(name, tool.execute, kwargs)
+
             # Validate parameters
             if hasattr(tool, "validate_parameters"):
                 tool.validate_parameters(**kwargs)
@@ -158,6 +164,8 @@ class ToolRegistry:
             result = tool.execute(**kwargs)
             return result
 
+        except (ToolArgumentError, ToolValidationError) as e:
+            return ToolResult(success=False, content="", error=f"Invalid arguments: {e}")
         except Exception as e:
             return ToolResult(success=False, content="", error=f"Tool execution failed: {type(e).__name__}: {e}")
 
@@ -187,6 +195,15 @@ def _truncate_text(value: str, max_chars: int) -> str:
     if max_chars <= 0 or len(value) <= max_chars:
         return value
     return value[: max_chars - 16].rstrip() + "\n...[truncated]"
+
+
+def _as_str_list(value: str | list[str] | None) -> list[str]:
+    """Accept either a single value or a list for list-typed tool parameters."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value else []
+    return [str(item) for item in value]
 
 
 _DEFAULT_EXA_MCP_URL = "https://mcp.exa.ai/mcp"
@@ -939,13 +956,17 @@ class GrepTool(BaseTool):
     def execute(  # type: ignore[override]
         self,
         pattern: str,
-        paths: list[str] | None = None,
+        paths: list[str] | str | None = None,
         ignore_case: bool = False,
         hidden: bool = False,
         context: int = 0,
-        globs: list[str] | None = None,
+        globs: list[str] | str | None = None,
     ) -> ToolResult:
-        """Execute grep search."""
+        """Execute grep search.
+
+        ``paths`` and ``globs`` are lists, but a single string is accepted too so
+        a caller passing one path does not have to wrap it in an array.
+        """
         import shutil
         import subprocess
 
@@ -954,15 +975,18 @@ class GrepTool(BaseTool):
                 success=False, content="", error="ripgrep (rg) not found on PATH. Please install ripgrep."
             )
 
+        search_paths = _as_str_list(paths) or ["."]
+        glob_filters = _as_str_list(globs)
+
         try:
-            cmd = ["rg", pattern, *(paths or ["."]), "-n"]
+            cmd = ["rg", pattern, *search_paths, "-n"]
             if ignore_case:
                 cmd.append("-i")
             if hidden:
                 cmd.append("--hidden")
             if context:
                 cmd.extend(["-C", str(context)])
-            for g in globs or []:
+            for g in glob_filters:
                 cmd.extend(["-g", g])
 
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
@@ -973,7 +997,7 @@ class GrepTool(BaseTool):
                     content=result.stdout,
                     metadata={
                         "pattern": pattern,
-                        "paths": paths or ["."],
+                        "paths": search_paths,
                         "match_count": len(result.stdout.splitlines()),
                     },
                 )
@@ -1002,7 +1026,11 @@ class GrepTool(BaseTool):
                 "paths": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Paths to search in (default: current directory)",
+                    "description": (
+                        "Files or directories to search, as a list (default: workspace root). "
+                        "The parameter is named 'paths', not 'path'; pass a single location as a "
+                        "one-element list, e.g. ['src/amcp']."
+                    ),
                 },
                 "ignore_case": {"type": "boolean", "description": "Case-insensitive search"},
                 "hidden": {"type": "boolean", "description": "Search hidden files and directories"},

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -11,7 +11,7 @@ import pytest
 from amcp.agent import Agent, AgentExecutionError, BusyError, MaxStepsReached
 from amcp.agent_spec import ResolvedAgentSpec
 from amcp.config import AMCPConfig, ChatConfig, ContextConfig
-from amcp.hooks import HookOutput
+from amcp.hooks import HookDecision, HookOutput
 from amcp.llm import LLMResponse, TokenUsage
 from amcp.memory import MemoryManager, MemoryStore
 from amcp.multi_agent import AgentMode
@@ -214,6 +214,54 @@ class TestAgentToolLimits:
         )
 
         assert result == "done"
+
+    @pytest.mark.asyncio
+    async def test_tool_aliases_are_normalized_before_pre_tool_hooks(self, tmp_path):
+        """Safety hooks inspect the canonical arguments that execution will use."""
+
+        class FakeLLM:
+            def __init__(self):
+                self.calls = 0
+
+            def chat(self, messages, **_kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    return SimpleNamespace(
+                        content="",
+                        tool_calls=[
+                            {
+                                "id": "call_1",
+                                "name": "bash",
+                                "arguments": json.dumps({"cmd": "blocked-command"}),
+                            }
+                        ],
+                    )
+                assert any(message.get("role") == "tool" for message in messages)
+                return SimpleNamespace(content="done", tool_calls=None)
+
+        with patch("amcp.agent.Path.home") as mock_home, patch("amcp.agent.load_config") as mock_load:
+            mock_home.return_value = tmp_path
+            mock_load.return_value = AMCPConfig(servers={}, chat=None, context=ContextConfig())
+            agent = Agent(session_id="test-session")
+
+        denied = HookOutput(decision=HookDecision.DENY, decision_reason="blocked")
+        with patch(
+            "amcp.agent.run_pre_tool_use_hooks",
+            new_callable=AsyncMock,
+            return_value=denied,
+        ) as pre_hook:
+            result = await agent._enhanced_chat_with_tools(
+                llm_client=FakeLLM(),
+                messages=[{"role": "user", "content": "run command"}],
+                tools=[create_default_tool_registry(enable_task=False).get_tool("bash").get_spec()],
+                tool_registry={},
+                stream=False,
+                status=MagicMock(),
+                work_dir=tmp_path,
+            )
+
+        assert result == "done"
+        assert pre_hook.await_args.kwargs["tool_input"] == {"command": "blocked-command"}
 
 
 class TestAgentHistoryManagement:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -234,6 +234,17 @@ class TestToolEndpoints:
         response = client.get("/api/v1/tools/nonexistent_tool")
         assert response.status_code == 404
 
+    def test_execute_tool_repairs_model_argument_aliases(self, client):
+        """Direct tool execution uses the same argument repair as agents."""
+        response = client.post("/api/v1/tools/think/execute", json={"text": "check"})
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "success": True,
+            "result": "🤔 Thinking: check",
+            "error": None,
+        }
+
 
 class TestAgentEndpoints:
     """Test agent management endpoints."""

--- a/tests/test_tool_arguments.py
+++ b/tests/test_tool_arguments.py
@@ -1,0 +1,147 @@
+"""Tests for model-supplied tool argument repair and validation."""
+
+import shutil
+
+import pytest
+
+from amcp.config import AMCPConfig
+from amcp.tool_execution import ToolCapability, ToolExecutionContext, ToolExecutor
+from amcp.tool_schema import (
+    ToolArgumentError,
+    normalize_tool_arguments,
+    validate_callable_arguments,
+)
+from amcp.tools import GrepTool, ReadFileTool, create_default_tool_registry
+
+requires_ripgrep = pytest.mark.skipif(shutil.which("rg") is None, reason="ripgrep (rg) is not installed")
+
+
+def _grep_schema():
+    return GrepTool().get_parameters_schema()
+
+
+def _executor(tmp_path, exposed=None):
+    return ToolExecutor(
+        context=ToolExecutionContext("session", tmp_path, "turn"),
+        capability=ToolCapability.from_spec(None, [], True),
+        exposed_tools=exposed or {"grep", "read_file", "bash", "web_search"},
+        registry=create_default_tool_registry(enable_task=False),
+        mcp_registry={},
+        config=AMCPConfig(servers={}, chat=None),
+    )
+
+
+def test_grep_path_alias_is_repaired_to_paths():
+    args = normalize_tool_arguments("grep", _grep_schema(), {"pattern": "api_type", "path": "src"})
+
+    assert args == {"pattern": "api_type", "paths": ["src"]}
+
+
+def test_explicit_paths_wins_over_alias():
+    for arguments in (
+        {"pattern": "x", "path": "alias", "paths": ["canonical"]},
+        {"pattern": "x", "paths": ["canonical"], "path": "alias"},
+    ):
+        assert normalize_tool_arguments("grep", _grep_schema(), arguments)["paths"] == ["canonical"]
+
+
+def test_scalar_and_json_string_values_are_widened_to_arrays():
+    schema = _grep_schema()
+
+    assert normalize_tool_arguments("grep", schema, {"pattern": "x", "globs": "*.py"})["globs"] == ["*.py"]
+    assert normalize_tool_arguments("grep", schema, {"pattern": "x", "paths": '["a", "b"]'})["paths"] == ["a", "b"]
+
+
+def test_stringified_scalars_are_coerced_to_declared_types():
+    args = normalize_tool_arguments(
+        "grep",
+        _grep_schema(),
+        {"pattern": "x", "ignore_case": "true", "context": "3"},
+    )
+
+    assert args["ignore_case"] is True
+    assert args["context"] == 3
+
+
+def test_unknown_parameter_reports_supported_names_and_suggestion():
+    with pytest.raises(ToolArgumentError) as excinfo:
+        normalize_tool_arguments("grep", _grep_schema(), {"pattern": "x", "pattrn": "y"})
+
+    message = str(excinfo.value)
+    assert "'pattrn'" in message
+    assert "did you mean 'pattern'?" in message
+    assert "Supported parameters: context, globs, hidden, ignore_case, paths, pattern" in message
+
+
+def test_missing_required_parameter_is_reported():
+    with pytest.raises(ToolArgumentError, match="missing required parameter"):
+        normalize_tool_arguments("grep", _grep_schema(), {"paths": ["src"]})
+
+
+def test_enum_and_bound_violations_are_reported():
+    read_schema = ReadFileTool().get_parameters_schema()
+
+    with pytest.raises(ToolArgumentError, match="must be one of: slice, indentation"):
+        normalize_tool_arguments("read_file", read_schema, {"path": "a.py", "mode": "lines"})
+    with pytest.raises(ToolArgumentError, match="must be <= 5000"):
+        normalize_tool_arguments("read_file", read_schema, {"path": "a.py", "max_lines": 99999})
+
+
+def test_runtime_owned_bash_cwd_is_dropped_not_rejected():
+    from amcp.tools import BashTool
+
+    args = normalize_tool_arguments("bash", BashTool().get_parameters_schema(), {"cmd": "ls", "cwd": "/tmp"})
+
+    assert args == {"command": "ls"}
+
+
+def test_signature_guard_replaces_typeerror_with_actionable_message():
+    with pytest.raises(ToolArgumentError) as excinfo:
+        validate_callable_arguments("grep", GrepTool().execute, {"pattern": "x", "path": "src"})
+
+    assert "did you mean 'paths'?" in str(excinfo.value)
+
+
+def test_registry_reports_invalid_arguments_instead_of_typeerror():
+    registry = create_default_tool_registry(enable_task=False)
+
+    result = registry.execute_tool("grep", pattern="x", path="src")
+
+    assert not result.success
+    assert result.error is not None
+    assert "TypeError" not in result.error
+    assert "Invalid arguments" in result.error
+    assert "did you mean 'paths'?" in result.error
+
+
+@requires_ripgrep
+def test_grep_tool_accepts_a_single_path_string(tmp_path):
+    (tmp_path / "sample.py").write_text("active_provider = 'openai'\n", encoding="utf-8")
+
+    result = GrepTool().execute(pattern="active_provider", paths=str(tmp_path))
+
+    assert result.success
+    assert "active_provider" in result.content
+    assert result.metadata["paths"] == [str(tmp_path)]
+
+
+@requires_ripgrep
+@pytest.mark.asyncio
+async def test_executor_repairs_grep_path_alias_within_workspace(tmp_path):
+    (tmp_path / "config.py").write_text("api_type = 'openai'\n", encoding="utf-8")
+
+    result = await _executor(tmp_path).execute("grep", {"pattern": "api_type", "path": "config.py"})
+
+    assert result.success
+    assert "api_type" in result.content
+    assert result.metadata["paths"] == [str((tmp_path / "config.py").resolve())]
+
+
+@pytest.mark.asyncio
+async def test_executor_returns_actionable_error_for_unsupported_parameter(tmp_path):
+    result = await _executor(tmp_path).execute("grep", {"pattern": "x", "recursive": True})
+
+    assert not result.success
+    assert result.error is not None
+    assert "does not support parameter(s): 'recursive'" in result.error
+    assert "Supported parameters" in result.error

--- a/tests/test_tool_arguments.py
+++ b/tests/test_tool_arguments.py
@@ -11,7 +11,7 @@ from amcp.tool_schema import (
     normalize_tool_arguments,
     validate_callable_arguments,
 )
-from amcp.tools import GrepTool, ReadFileTool, create_default_tool_registry
+from amcp.tools import BashTool, GrepTool, ReadFileTool, create_default_tool_registry
 
 requires_ripgrep = pytest.mark.skipif(shutil.which("rg") is None, reason="ripgrep (rg) is not installed")
 
@@ -88,11 +88,23 @@ def test_enum_and_bound_violations_are_reported():
 
 
 def test_runtime_owned_bash_cwd_is_dropped_not_rejected():
-    from amcp.tools import BashTool
-
     args = normalize_tool_arguments("bash", BashTool().get_parameters_schema(), {"cmd": "ls", "cwd": "/tmp"})
 
     assert args == {"command": "ls"}
+
+
+def test_executor_prepares_aliases_before_safety_hooks(tmp_path):
+    args = _executor(tmp_path).prepare_arguments("bash", {"cmd": "rm -rf important"})
+
+    assert args == {"command": "rm -rf important"}
+
+
+def test_registry_prepares_model_arguments_for_non_agent_entry_points():
+    registry = create_default_tool_registry(enable_task=False)
+
+    args = registry.prepare_arguments("grep", {"pattern": "x", "path": "src"})
+
+    assert args == {"pattern": "x", "paths": ["src"]}
 
 
 def test_signature_guard_replaces_typeerror_with_actionable_message():


### PR DESCRIPTION
# Pull Request

## Description
A tool call like `grep(pattern=..., path=...)` reached `GrepTool.execute()` unchanged and failed with:

```
Error: Tool execution failed: TypeError: GrepTool.execute() got an unexpected keyword argument 'path'. Did you mean 'paths'?
```

Each tool's JSON schema (including `additionalProperties: false`) was only used to *describe* tools to the model; at execution time arguments went straight into `execute(**kwargs)` via `ToolRegistry.execute_tool`, so a near-miss parameter name became an opaque Python `TypeError`. Worse, `ToolExecutor._bind_arguments` also injected `paths=[workspace_root]` when `paths` was absent, so the call carried both `path` and `paths` and the model could never recover from the error text. In practice models gave up on the tool and fell back to `bash` + `grep`.

Changes:

- **New `src/amcp/tool_schema.py`** — repair and validation for model-supplied arguments:
  - Per-tool alias table (`grep`: `path`/`file`/`dir`/`search_path` → `paths`, `glob`/`include` → `globs`, `regex`/`query` → `pattern`; plus `read_file`, `write_file`, `bash`, `apply_patch`, `memory`, `session_search`, `web_search`, `web_fetch`, `todo`, `task`, `think`). Alias keys are matched after case/separator folding, and an alias never shadows an explicitly supplied canonical parameter.
  - Schema-driven coercion: scalars widened to arrays, JSON-string arrays/objects parsed, stringified scalars (`"true"`, `"3"`) coerced to the declared type.
  - Anything unrepairable becomes an actionable message listing supported parameters plus the closest match (`did you mean 'paths'?`), so the model can fix the call on the next attempt instead of routing around the tool.
  - `IGNORED_PARAMETERS` preserves existing behavior for runtime-owned parameters: a model-supplied `bash` `cwd` is still dropped silently rather than rejected, because `bash` always runs in the trusted workspace root.
  - `validate_callable_arguments()` uses `inspect.signature` as a last-resort guard so an unbindable kwarg can never surface as a raw `TypeError`.
- **`ToolExecutor.execute`** normalizes arguments *before* `_bind_arguments`, so alias repair happens before trusted runtime values are injected (otherwise `path` + injected `paths` still collide). MCP tools own their schemas remotely and are passed through untouched.
- **`ToolRegistry.execute_tool`** validates bindability first and reports `Invalid arguments: ...`.
- **HTTP `/tools/{name}/execute`** now goes through the registry, so direct API calls get the same validation as agent-driven calls.
- **`GrepTool`** accepts a single string for `paths`/`globs`, and its schema states the parameter is the plural `paths`.
- **`AGENTS.md`** documents the new layer so future tools register aliases there instead of widening `execute()` signatures.

Not addressed here (separate issue, same original report): `GrepTool`'s hardcoded 30s timeout and lack of output truncation.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Testing
New `tests/test_tool_arguments.py` (13 tests) covers alias repair, alias-vs-canonical precedence, scalar/JSON-string → array widening, stringified scalar coercion, unknown-parameter and missing-required messages, enum/bounds violations, `bash` `cwd` dropping, the signature guard, and end-to-end `path` → `paths` repair through `ToolExecutor`. Tests that shell out to `rg` skip when ripgrep is unavailable.

```bash
ruff format src tests
ruff check src tests
mypy src/amcp --ignore-missing-imports
python -m pytest -q -m "not llm"
```

Results: lint and format clean, mypy reports no issues in 82 source files, 794 tests passed.

## Related Issues
<!-- Link to related issues -->
N/A

---
Agent conversation: https://app.warp.dev/conversation/865c3af2-fa0d-45c9-892e-3196b2952d86
