### PR TITLE
fix: accept singular path for grep tool calls

### DIFF
--- a/src/amcp/agent.py
+++ b/src/amcp/agent.py
@@ -1508,6 +1508,11 @@ class Agent:
                             )
                             continue
 
+                        # Hooks must inspect the same canonical arguments that
+                        # execution will use. For example, grep's common
+                        # ``path`` near-miss becomes ``paths`` here.
+                        args = executor.prepare_model_arguments(tool_name, args)
+
                         # Run PreToolUse hooks
                         pre_hook_output = await run_pre_tool_use_hooks(
                             session_id=self.session_id,

--- a/src/amcp/server/routes/tools.py
+++ b/src/amcp/server/routes/tools.py
@@ -97,7 +97,8 @@ async def execute_tool(tool_name: str, arguments: dict[str, Any]) -> dict:
         )
 
     try:
-        result = tool_func.execute(**arguments)
+        arguments = tool_registry.prepare_model_arguments(tool_name, arguments)
+        result = tool_registry.execute_tool(tool_name, **arguments)
 
         if isinstance(result, ToolResult):
             return {

--- a/src/amcp/tool_execution.py
+++ b/src/amcp/tool_execution.py
@@ -175,6 +175,7 @@ class ToolExecutor:
         if name not in self.exposed_tools or not self.capability.allows(name):
             raise ToolPermissionError(f"Tool '{name}' is not authorized for this turn")
 
+        arguments = self.prepare_model_arguments(name, arguments)
         args = self._bind_arguments(name, arguments)
         if name.startswith("mcp."):
             return await self._execute_mcp(name, args)
@@ -186,6 +187,12 @@ class ToolExecutor:
         if name == "bash":
             return await self._execute_bash(args)
         return await asyncio.to_thread(self.registry.execute_tool, name, **args)
+
+    def prepare_model_arguments(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Canonicalize model input before hooks or trusted runtime binding."""
+        if name.startswith("mcp."):
+            return dict(arguments)
+        return self.registry.prepare_model_arguments(name, arguments)
 
     def _bind_arguments(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         args = dict(arguments)

--- a/src/amcp/tools.py
+++ b/src/amcp/tools.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import difflib
+import inspect
 import os
 import threading
 from abc import ABC, abstractmethod
@@ -93,6 +95,10 @@ class BaseTool(ABC):
         """Validate tool parameters. Override in subclasses."""
         pass
 
+    def prepare_model_arguments(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Normalize model-supplied arguments before hooks and execution."""
+        return dict(arguments)
+
     def get_spec(self) -> dict[str, Any]:
         """Get tool specification for LLM."""
         return {
@@ -143,6 +149,13 @@ class ToolRegistry:
         """Get all tool specifications."""
         return self._tool_specs.copy()
 
+    def prepare_model_arguments(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Normalize untrusted arguments using the owning tool's narrow rules."""
+        tool = self.get_tool(name)
+        if tool is None:
+            return dict(arguments)
+        return tool.prepare_model_arguments(arguments)
+
     def execute_tool(self, name: str, **kwargs) -> ToolResult:
         """Execute a tool by name."""
         tool = self.get_tool(name)
@@ -150,6 +163,8 @@ class ToolRegistry:
             return ToolResult(success=False, content="", error=f"Tool '{name}' not found")
 
         try:
+            _validate_callable_arguments(name, tool.execute, kwargs)
+
             # Validate parameters
             if hasattr(tool, "validate_parameters"):
                 tool.validate_parameters(**kwargs)
@@ -158,8 +173,33 @@ class ToolRegistry:
             result = tool.execute(**kwargs)
             return result
 
+        except ToolValidationError as e:
+            return ToolResult(success=False, content="", error=f"Invalid arguments: {e}")
         except Exception as e:
             return ToolResult(success=False, content="", error=f"Tool execution failed: {type(e).__name__}: {e}")
+
+
+def _validate_callable_arguments(name: str, func: Callable[..., Any], arguments: dict[str, Any]) -> None:
+    """Reject unbindable keyword arguments with an actionable error."""
+    signature = inspect.signature(func)
+    try:
+        signature.bind(**arguments)
+    except TypeError as exc:
+        accepted = [
+            parameter_name
+            for parameter_name, parameter in signature.parameters.items()
+            if parameter.kind in {inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY}
+        ]
+        unknown = [argument for argument in arguments if argument not in accepted]
+        if unknown:
+            invalid = unknown[0]
+            suggestion = difflib.get_close_matches(invalid, accepted, n=1, cutoff=0.5)
+            hint = f" Did you mean '{suggestion[0]}'?" if suggestion else ""
+            supported = ", ".join(sorted(accepted))
+            raise ToolValidationError(
+                f"Tool '{name}' does not support parameter '{invalid}'.{hint} Supported parameters: {supported}."
+            ) from exc
+        raise ToolValidationError(f"Tool '{name}' arguments do not match its signature: {exc}") from exc
 
 
 def _run_coroutine_in_thread(coro: Any) -> Any:
@@ -935,6 +975,15 @@ class GrepTool(BaseTool):
     @property
     def description(self) -> str:
         return "Search for patterns in files using ripgrep. Returns matching lines with file paths and line numbers."
+
+    def prepare_model_arguments(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Accept the common singular ``path`` near-miss without changing the tool API."""
+        prepared = dict(arguments)
+        if "paths" in prepared:
+            prepared.pop("path", None)
+        elif isinstance(prepared.get("path"), str):
+            prepared["paths"] = [prepared.pop("path")]
+        return prepared
 
     def execute(  # type: ignore[override]
         self,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -11,7 +11,7 @@ import pytest
 from amcp.agent import Agent, AgentExecutionError, BusyError, MaxStepsReached
 from amcp.agent_spec import ResolvedAgentSpec
 from amcp.config import AMCPConfig, ChatConfig, ContextConfig
-from amcp.hooks import HookOutput
+from amcp.hooks import HookDecision, HookOutput
 from amcp.llm import LLMResponse, TokenUsage
 from amcp.memory import MemoryManager, MemoryStore
 from amcp.multi_agent import AgentMode
@@ -214,6 +214,57 @@ class TestAgentToolLimits:
         )
 
         assert result == "done"
+
+    @pytest.mark.asyncio
+    async def test_grep_path_is_canonicalized_before_pre_tool_hooks(self, tmp_path):
+        """Hooks inspect grep's canonical paths argument rather than its alias."""
+
+        class FakeLLM:
+            def __init__(self):
+                self.calls = 0
+
+            def chat(self, messages, **_kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    return SimpleNamespace(
+                        content="",
+                        tool_calls=[
+                            {
+                                "id": "call_1",
+                                "name": "grep",
+                                "arguments": json.dumps({"pattern": "needle", "path": "src"}),
+                            }
+                        ],
+                    )
+                assert any(message.get("role") == "tool" for message in messages)
+                return SimpleNamespace(content="done", tool_calls=None)
+
+        with patch("amcp.agent.Path.home") as mock_home, patch("amcp.agent.load_config") as mock_load:
+            mock_home.return_value = tmp_path
+            mock_load.return_value = AMCPConfig(servers={}, chat=None, context=ContextConfig())
+            agent = Agent(session_id="test-session")
+
+        denied = HookOutput(decision=HookDecision.DENY, decision_reason="test")
+        with patch(
+            "amcp.agent.run_pre_tool_use_hooks",
+            new_callable=AsyncMock,
+            return_value=denied,
+        ) as pre_hook:
+            result = await agent._enhanced_chat_with_tools(
+                llm_client=FakeLLM(),
+                messages=[{"role": "user", "content": "search"}],
+                tools=[create_default_tool_registry(enable_task=False).get_tool("grep").get_spec()],
+                tool_registry={},
+                stream=False,
+                status=MagicMock(),
+                work_dir=tmp_path,
+            )
+
+        assert result == "done"
+        assert pre_hook.await_args.kwargs["tool_input"] == {
+            "pattern": "needle",
+            "paths": ["src"],
+        }
 
 
 class TestAgentHistoryManagement:

--- a/tests/test_execution_boundaries.py
+++ b/tests/test_execution_boundaries.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import shutil
 from contextlib import suppress
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -114,6 +115,31 @@ async def test_read_write_patch_and_bash_share_runtime_workspace(tmp_path):
     assert bash.success
     assert str(tmp_path.resolve()) in bash.content
     assert (tmp_path / "file.txt").read_text(encoding="utf-8") == "new\n"
+
+
+@pytest.mark.skipif(shutil.which("rg") is None, reason="ripgrep is not installed")
+@pytest.mark.asyncio
+async def test_grep_singular_path_is_repaired_before_workspace_binding(tmp_path):
+    (tmp_path / "sample.py").write_text("needle = True\n", encoding="utf-8")
+    executor = _executor(tmp_path, exposed={"grep"})
+
+    result = await executor.execute("grep", {"pattern": "needle", "path": "sample.py"})
+
+    assert result.success
+    assert "needle = True" in result.content
+    assert result.metadata["paths"] == [str((tmp_path / "sample.py").resolve())]
+
+
+@pytest.mark.asyncio
+async def test_grep_does_not_repair_non_string_path(tmp_path):
+    executor = _executor(tmp_path, exposed={"grep"})
+
+    result = await executor.execute("grep", {"pattern": "needle", "path": None})
+
+    assert not result.success
+    assert result.error is not None
+    assert result.error.startswith("Invalid arguments:")
+    assert "does not support parameter 'path'" in result.error
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,7 +2,16 @@ import json
 import re
 from unittest.mock import patch
 
-from amcp.tools import BashTool, ReadFileTool, ThinkTool, TodoTool, WebFetchTool, WebSearchTool, get_tool_registry
+from amcp.tools import (
+    BashTool,
+    GrepTool,
+    ReadFileTool,
+    ThinkTool,
+    TodoTool,
+    WebFetchTool,
+    WebSearchTool,
+    get_tool_registry,
+)
 
 
 def test_read_file_tool(tmp_path):
@@ -47,6 +56,33 @@ def test_think_tool():
     result = tool.execute(thought="test reasoning")
     assert result.success
     assert "test reasoning" in result.content
+
+
+def test_grep_repairs_singular_path_without_changing_its_public_api():
+    tool = GrepTool()
+
+    assert tool.prepare_model_arguments({"pattern": "x", "path": "src"}) == {
+        "pattern": "x",
+        "paths": ["src"],
+    }
+    assert tool.prepare_model_arguments({"pattern": "x", "path": "alias", "paths": ["canonical"]}) == {
+        "pattern": "x",
+        "paths": ["canonical"],
+    }
+    assert tool.prepare_model_arguments({"pattern": "x", "path": None}) == {
+        "pattern": "x",
+        "path": None,
+    }
+
+
+def test_registry_reports_unbindable_arguments_without_raw_typeerror():
+    result = get_tool_registry().execute_tool("grep", pattern="x", path="src")
+
+    assert not result.success
+    assert result.error is not None
+    assert result.error.startswith("Invalid arguments:")
+    assert "Did you mean 'paths'?" in result.error
+    assert "TypeError" not in result.error
 
 
 def test_web_search_tool_firecrawl_backend():


### PR DESCRIPTION
# Pull Request

## Description

Fix model-generated `grep(path=...)` calls without introducing a general-purpose argument coercion layer.

`GrepTool` keeps `paths: list[str]` as its canonical public API because ripgrep supports searching multiple roots. At the model-input boundary, the tool now narrowly repairs a string `path` alias to a one-element `paths` list. Canonical `paths` wins when both are present, while malformed non-string `path` values remain invalid.

Argument preparation runs before `PreToolUse` hooks and again before trusted workspace binding, so hooks inspect the same canonical input that execution uses. MCP arguments remain untouched. Direct HTTP tool execution uses the same narrow preparation path.

The registry also validates callable binding before execution, replacing raw Python `TypeError` failures with an actionable error that lists supported parameters and suggests the closest match.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing

```bash
ruff format --check src/amcp/tools.py src/amcp/tool_execution.py src/amcp/agent.py src/amcp/server/routes/tools.py tests/test_tools.py tests/test_agent.py tests/test_execution_boundaries.py
ruff check src/amcp/tools.py src/amcp/tool_execution.py src/amcp/agent.py src/amcp/server/routes/tools.py tests/test_tools.py tests/test_agent.py tests/test_execution_boundaries.py
python -m pytest -q -m "not llm"
```

Results: 786 tests passed. `mypy src/amcp --ignore-missing-imports` still reports four pre-existing `Task`/`Future` errors in `src/amcp/tools.py` outside this change.

## Related Issues

N/A
