### PR TITLE
fix: provider compatibility for tool calls (Gemini pairing, Kimi function names)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,9 +334,11 @@ command = "npx"
 args = ["-y", "@some/mcp-server"]
 ```
 
-Configured MCP servers are exposed as `mcp.<server>.<tool>` tools. The built-in
-`web_search` and `web_fetch` tools are available separately and work out of the
-box without adding a search MCP server.
+Configured MCP servers are exposed as `mcp__<server>__<tool>` tools. Server and
+tool names are sanitized into `[A-Za-z][A-Za-z0-9_-]*`, because some providers
+(for example Kimi/Moonshot) reject any other function name with HTTP 400. The
+built-in `web_search` and `web_fetch` tools are available separately and work
+out of the box without adding a search MCP server.
 
 ### Context Optimization
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -270,7 +270,7 @@ List all available tools.
       "source": "builtin"
     },
     {
-      "name": "mcp.filesystem.read_file",
+      "name": "mcp__filesystem__read_file",
       "description": "Read file via MCP",
       "parameters": {...},
       "source": "mcp"

--- a/docs/phase9-progressive-view.md
+++ b/docs/phase9-progressive-view.md
@@ -56,7 +56,7 @@ Default tiers (configurable):
 
 - `ALWAYS`: `read_file`, `grep`, `think`
 - `FREQUENT`: `apply_patch`, `write_file`, `bash`, `todo`
-- `ON_DEMAND`: `memory`, `task`, `mcp.*`
+- `ON_DEMAND`: `memory`, `task`, `mcp__*`
 - `HIDDEN`: only when explicitly set via `tool_tiers`
 
 > This is safer than forcing write tools into `ALWAYS`: it preserves implementation capability while reducing irrelevant noise.
@@ -121,7 +121,7 @@ bash = "frequent"
 todo = "frequent"
 memory = "on_demand"
 task = "on_demand"
-mcp.* = "on_demand"
+"mcp__*" = "on_demand"   # matches every MCP tool; legacy "mcp.*" is still read
 ```
 
 ---

--- a/src/amcp/agent.py
+++ b/src/amcp/agent.py
@@ -35,6 +35,7 @@ from .hooks import (
     run_user_prompt_hooks,
 )
 from .mcp_client import list_mcp_tools
+from .mcp_naming import is_mcp_tool_name, mcp_tool_name, unique_function_name
 from .memory import get_memory_manager
 from .memory_review import MEMORY_GUIDANCE, run_memory_review
 from .message_queue import MessagePriority
@@ -93,22 +94,23 @@ def _repair_tool_call_pairing(messages: list[dict[str, Any]]) -> list[dict[str, 
     repaired: list[dict[str, Any]] = []
     pending_ids: list[str] = []
     pending_names: dict[str, str] = {}
-    pending_extras: dict[str, dict[str, Any]] = {}
 
     def flush_pending() -> None:
         for call_id in pending_ids:
             tool_result: dict[str, Any] = {
                 "role": "tool",
                 "tool_call_id": call_id,
-                "name": pending_names.get(call_id, ""),
                 "content": "[Tool result unavailable: synthesized to keep tool-call history paired]",
             }
-            if call_id in pending_extras:
-                tool_result["extra_content"] = pending_extras[call_id]
+            # Strict providers reject an empty function name, so only carry the
+            # name when the paired call actually reported one. Provider
+            # extra_content (e.g. Gemini thought signatures) stays on the call.
+            paired_name = pending_names.get(call_id)
+            if paired_name:
+                tool_result["name"] = paired_name
             repaired.append(tool_result)
         pending_ids.clear()
         pending_names.clear()
-        pending_extras.clear()
 
     for message in messages:
         role = message.get("role")
@@ -124,9 +126,6 @@ def _repair_tool_call_pairing(messages: list[dict[str, Any]]) -> list[dict[str, 
                     function = call.get("function")
                     if isinstance(function, dict) and isinstance(function.get("name"), str):
                         pending_names[call_id] = function["name"]
-                    extra_content = call.get("extra_content")
-                    if isinstance(extra_content, dict) and extra_content:
-                        pending_extras[call_id] = extra_content
         elif role == "tool":
             call_id = message.get("tool_call_id")
             if call_id in pending_ids:
@@ -655,7 +654,7 @@ class Agent:
                 for tool in tools:
                     tools_info.append(
                         {
-                            "name": f"mcp.{server_name}.{tool['name']}",
+                            "name": mcp_tool_name(server_name, tool["name"]),
                             "description": tool.get("description", ""),
                             "server": server_name,
                         }
@@ -695,7 +694,7 @@ class Agent:
             return False
 
         # MCP tools: 100 per tool per conversation
-        return tool_name.startswith("mcp.") and current_conversation_calls >= 100
+        return is_mcp_tool_name(tool_name) and current_conversation_calls >= 100
 
     def _resolve_bash_tool_limit(self) -> int:
         """Resolve the per-request bash limit; values <= 0 disable this limit."""
@@ -1223,16 +1222,22 @@ class Agent:
         else:
             selected = list(cfg.servers.keys())
 
-        # Load MCP tools asynchronously (single call per server)
+        # Load MCP tools asynchronously (single call per server). Server and
+        # tool names are untrusted, and providers disagree on legal function
+        # names (Kimi rejects the dots Gemini accepts), so every MCP tool is
+        # exposed under a sanitized alias that the registry maps back to its
+        # (server, tool) pair.
+        exposed_names = {tool_name for tool in tools if (tool_name := tool.get("function", {}).get("name"))}
         for name in selected:
             try:
                 server = cfg.servers[name]
                 info_list = await list_mcp_tools(server)
                 for info in info_list:
                     tname = info.get("name") or "tool"
-                    oname = f"mcp.{name}.{tname}"
+                    oname = unique_function_name(mcp_tool_name(name, tname), exposed_names)
                     if not capability.allows(oname):
                         continue
+                    exposed_names.add(oname)
                     params = info.get("inputSchema") or {"type": "object"}
                     tools.append(
                         {

--- a/src/amcp/agent.py
+++ b/src/amcp/agent.py
@@ -71,13 +71,79 @@ MEMORY_LOG_AGENT_LIMIT = 2000
 class AgentExecutionError(Exception):
     """Raised when agent execution fails."""
 
-    pass
+    def __init__(self, message: str, retryable: bool = False) -> None:
+        super().__init__(message)
+        self.retryable = retryable
 
 
 class MaxStepsReached(Exception):
     """Raised when agent reaches maximum execution steps."""
 
     pass
+
+
+def _repair_tool_call_pairing(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Ensure assistant tool_calls and tool results stay strictly paired.
+
+    Gemini-family backends reject requests where a function-call turn is not
+    followed by exactly one function-response part per call. History that
+    passes through trimming or compaction can lose responses, so missing ones
+    are synthesized and orphaned tool results are dropped.
+    """
+    repaired: list[dict[str, Any]] = []
+    pending_ids: list[str] = []
+    pending_names: dict[str, str] = {}
+    pending_extras: dict[str, dict[str, Any]] = {}
+
+    def flush_pending() -> None:
+        for call_id in pending_ids:
+            tool_result: dict[str, Any] = {
+                "role": "tool",
+                "tool_call_id": call_id,
+                "name": pending_names.get(call_id, ""),
+                "content": "[Tool result unavailable: synthesized to keep tool-call history paired]",
+            }
+            if call_id in pending_extras:
+                tool_result["extra_content"] = pending_extras[call_id]
+            repaired.append(tool_result)
+        pending_ids.clear()
+        pending_names.clear()
+        pending_extras.clear()
+
+    for message in messages:
+        role = message.get("role")
+        if role == "assistant" and message.get("tool_calls"):
+            flush_pending()
+            repaired.append(message)
+            for call in message["tool_calls"]:
+                if not isinstance(call, dict):
+                    continue
+                call_id = call.get("id")
+                if isinstance(call_id, str) and call_id:
+                    pending_ids.append(call_id)
+                    function = call.get("function")
+                    if isinstance(function, dict) and isinstance(function.get("name"), str):
+                        pending_names[call_id] = function["name"]
+                    extra_content = call.get("extra_content")
+                    if isinstance(extra_content, dict) and extra_content:
+                        pending_extras[call_id] = extra_content
+        elif role == "tool":
+            call_id = message.get("tool_call_id")
+            if call_id in pending_ids:
+                pending_ids.remove(call_id)
+                repaired.append(message)
+            # Orphaned tool results are dropped.
+        else:
+            flush_pending()
+            repaired.append(message)
+    flush_pending()
+    return repaired
+
+
+def _is_tool_call_pairing_error(error: Exception) -> bool:
+    """Check whether an error is a provider-side tool-call pairing rejection."""
+    text = str(error).lower()
+    return "function response parts" in text or ("function call" in text and "invalid_argument" in text)
 
 
 class BusyError(Exception):
@@ -1372,16 +1438,41 @@ class Agent:
 
             messages = self._fit_tool_context(messages, tools, input_token_budget)
             estimated_input_tokens = estimate_request_tokens(messages, tools)
-            resp = await self._call_llm(
-                llm_client,
-                messages=messages,
-                tools=tools,
-                stream_callback=stream_callback,
-            )
+            try:
+                resp = await self._call_llm(
+                    llm_client,
+                    messages=messages,
+                    tools=tools,
+                    stream_callback=stream_callback,
+                )
+            except Exception as call_error:
+                if not _is_tool_call_pairing_error(call_error):
+                    raise
+                logger.warning(
+                    "Provider rejected tool-call history (%s); repairing pairing and retrying once",
+                    call_error,
+                )
+                messages = _repair_tool_call_pairing(messages)
+                estimated_input_tokens = estimate_request_tokens(messages, tools)
+                resp = await self._call_llm(
+                    llm_client,
+                    messages=messages,
+                    tools=tools,
+                    stream_callback=stream_callback,
+                )
             self._record_llm_usage(resp, estimated_input_tokens, context_window)
 
             if resp.tool_calls:
-                tool_calls = normalize_tool_calls(resp.tool_calls)
+                try:
+                    tool_calls = normalize_tool_calls(resp.tool_calls)
+                except ToolCallProtocolError as protocol_error:
+                    if protocol_error.tool_calls is None:
+                        raise
+                    logger.warning(
+                        "Provider returned malformed tool calls (%s); synthesizing tool results",
+                        protocol_error,
+                    )
+                    tool_calls = normalize_tool_calls(protocol_error.tool_calls)
                 used_tools = True
                 status.update(f"[bold]Agent {self.name}[/bold] - Executing {len(tool_calls)} tool(s)...")
 
@@ -1410,6 +1501,7 @@ class Agent:
                                         "arguments": tc.raw_arguments,
                                     },
                                 }
+                                | ({"extra_content": tc.extra_content} if tc.extra_content else {})
                                 for tc in tool_calls
                             ],
                         }
@@ -1460,6 +1552,7 @@ class Agent:
                                     "arguments": tc.raw_arguments,
                                 },
                             }
+                            | ({"extra_content": tc.extra_content} if tc.extra_content else {})
                             for tc in tool_calls
                         ],
                     }
@@ -1742,10 +1835,10 @@ class Agent:
         token_budget: int,
     ) -> list[dict[str, Any]]:
         """Fit request-local tool exchanges into the model input budget."""
-        if estimate_request_tokens(messages, tools) <= token_budget:
-            return messages
-
         fitted = [dict(message) for message in messages]
+        if estimate_request_tokens(fitted, tools) <= token_budget:
+            return _repair_tool_call_pairing(fitted)
+
         tool_indexes = [i for i, message in enumerate(fitted) if message.get("role") == "tool"]
 
         # Retain useful head/tail excerpts, shrinking oldest results first.
@@ -1787,7 +1880,7 @@ class Agent:
         for message in fitted:
             if message.get("role") == "tool" and message.get("content"):
                 message["content"] = "[Tool result omitted: context budget exceeded]"
-        return fitted
+        return _repair_tool_call_pairing(fitted)
 
     def _create_progress_context(self, show_progress: bool):
         """Create progress display context."""

--- a/src/amcp/config.py
+++ b/src/amcp/config.py
@@ -270,7 +270,7 @@ _DEFAULT = {
             "todo": "frequent",
             "memory": "on_demand",
             "task": "on_demand",
-            "mcp.*": "on_demand",
+            "mcp__*": "on_demand",
         },
     },
     "telegram": {

--- a/src/amcp/llm.py
+++ b/src/amcp/llm.py
@@ -80,6 +80,14 @@ def _reasoning_content(value: Any) -> str | None:
     return str(legacy) if legacy else None
 
 
+def _extra_content(value: Any) -> dict[str, Any] | None:
+    """Extract provider extra_content (e.g., Gemini thought_signature) if present."""
+    extra = _response_field(value, "extra_content")
+    if isinstance(extra, dict) and extra:
+        return extra
+    return None
+
+
 @dataclass
 class TokenUsage:
     """Normalized token usage returned by an LLM provider."""
@@ -232,7 +240,7 @@ class AnyLLMClient(BaseLLMClient):
             # Streaming mode
             accumulated_content = []
             accumulated_reasoning = []
-            tool_calls_chunks = {}  # index -> accumulated chunk
+            tool_calls_chunks: dict[int, dict[str, Any]] = {}  # index -> accumulated chunk
             finish_reason = None
             usage = None
 
@@ -266,7 +274,7 @@ class AnyLLMClient(BaseLLMClient):
                     for tc in delta_tool_calls:
                         idx = _response_field(tc, "index", 0)
                         if idx not in tool_calls_chunks:
-                            tool_calls_chunks[idx] = {"id": "", "name": "", "arguments": ""}
+                            tool_calls_chunks[idx] = {"id": "", "name": "", "arguments": "", "extra_content": None}
 
                         tool_call_id = _response_field(tc, "id")
                         if tool_call_id:
@@ -279,6 +287,9 @@ class AnyLLMClient(BaseLLMClient):
                                 tool_calls_chunks[idx]["name"] += name
                             if arguments:
                                 tool_calls_chunks[idx]["arguments"] += arguments
+                        extra_content = _extra_content(tc)
+                        if extra_content is not None:
+                            tool_calls_chunks[idx]["extra_content"] = extra_content
 
             # Reconstruct full response
             content = "".join(accumulated_content) if accumulated_content else None
@@ -288,7 +299,10 @@ class AnyLLMClient(BaseLLMClient):
             if tool_calls_chunks:
                 for idx in sorted(tool_calls_chunks.keys()):
                     tc = tool_calls_chunks[idx]
-                    tool_calls.append({"id": tc["id"], "name": tc["name"], "arguments": tc["arguments"]})
+                    tool_call: dict[str, Any] = {"id": tc["id"], "name": tc["name"], "arguments": tc["arguments"]}
+                    if tc.get("extra_content"):
+                        tool_call["extra_content"] = tc["extra_content"]
+                    tool_calls.append(tool_call)
 
             if reasoning_text and not content and not tool_calls:
                 callback(reasoning_text)
@@ -318,11 +332,14 @@ class AnyLLMClient(BaseLLMClient):
             message_tool_calls = _response_field(msg, "tool_calls")
             if message_tool_calls:
                 tool_calls = [
-                    {
-                        "id": _response_field(tc, "id"),
-                        "name": _response_field(_response_field(tc, "function"), "name"),
-                        "arguments": _response_field(_response_field(tc, "function"), "arguments", "{}"),
-                    }
+                    (
+                        {
+                            "id": _response_field(tc, "id"),
+                            "name": _response_field(_response_field(tc, "function"), "name"),
+                            "arguments": _response_field(_response_field(tc, "function"), "arguments", "{}"),
+                        }
+                        | ({"extra_content": extra} if (extra := _extra_content(tc)) else {})
+                    )
                     for tc in message_tool_calls
                 ]
 
@@ -370,15 +387,18 @@ class AnyLLMClient(BaseLLMClient):
             tool_calls = None
             if message_tool_calls:
                 tool_calls = [
-                    {
-                        "id": _response_field(call, "id"),
-                        "name": _response_field(_response_field(call, "function"), "name"),
-                        "arguments": _response_field(
-                            _response_field(call, "function"),
-                            "arguments",
-                            "{}",
-                        ),
-                    }
+                    (
+                        {
+                            "id": _response_field(call, "id"),
+                            "name": _response_field(_response_field(call, "function"), "name"),
+                            "arguments": _response_field(
+                                _response_field(call, "function"),
+                                "arguments",
+                                "{}",
+                            ),
+                        }
+                        | ({"extra_content": extra} if (extra := _extra_content(call)) else {})
+                    )
                     for call in message_tool_calls
                 ]
             thinking, content = _split_response_content(
@@ -396,7 +416,7 @@ class AnyLLMClient(BaseLLMClient):
 
         accumulated_content: list[str] = []
         accumulated_reasoning: list[str] = []
-        tool_call_chunks: dict[int, dict[str, str]] = {}
+        tool_call_chunks: dict[int, dict[str, Any]] = {}
         finish_reason = None
         usage = None
         response_stream = await self.client.acompletion(**params)
@@ -420,17 +440,23 @@ class AnyLLMClient(BaseLLMClient):
                 index = _response_field(call, "index", 0)
                 current = tool_call_chunks.setdefault(
                     index,
-                    {"id": "", "name": "", "arguments": ""},
+                    {"id": "", "name": "", "arguments": "", "extra_content": None},
                 )
                 current["id"] += _response_field(call, "id", "") or ""
                 function = _response_field(call, "function")
                 if function:
                     current["name"] += _response_field(function, "name", "") or ""
                     current["arguments"] += _response_field(function, "arguments", "") or ""
+                extra = _extra_content(call)
+                if extra is not None:
+                    current["extra_content"] = extra
 
         content_text = "".join(accumulated_content) or None
         reasoning_text = "".join(accumulated_reasoning) or None
-        tool_calls = [tool_call_chunks[index] for index in sorted(tool_call_chunks)] or None
+        tool_calls = [
+            ({k: v for k, v in chunk.items() if k != "extra_content" or v})
+            for chunk in (tool_call_chunks[index] for index in sorted(tool_call_chunks))
+        ] or None
         if reasoning_text and not content_text and not tool_calls:
             stream_callback(reasoning_text)
         thinking, content_text = _split_response_content(

--- a/src/amcp/mcp_naming.py
+++ b/src/amcp/mcp_naming.py
@@ -1,0 +1,81 @@
+"""Provider-safe function names for tools exposed to LLM backends.
+
+Providers disagree on what a function name may contain. Gemini and GLM accept
+dots, while Kimi/Moonshot rejects every name outside ``[A-Za-z][A-Za-z0-9_-]*``
+with an HTTP 400 (``function name is invalid``). AMCP therefore exposes MCP
+tools under the strictest common form (``mcp__<server>__<tool>``) and keeps the
+original server/tool pair in the dispatch registry so the alias stays
+reversible.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Container
+
+# Model-facing namespace for MCP tools.
+MCP_TOOL_PREFIX = "mcp__"
+MCP_NAME_SEPARATOR = "__"
+
+# ``tool_tiers`` wildcard keys that apply to every MCP tool. The dotted key is
+# the pre-``mcp__`` spelling and stays supported for existing configurations.
+MCP_TOOL_TIER_KEY = "mcp__*"
+LEGACY_MCP_TOOL_TIER_KEY = "mcp.*"
+
+# OpenAI-compatible backends cap function names at 64 characters.
+MAX_FUNCTION_NAME_LENGTH = 64
+
+_VALID_FUNCTION_NAME = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+_INVALID_FUNCTION_NAME_CHARS = re.compile(r"[^A-Za-z0-9_-]")
+
+
+def is_valid_function_name(name: str) -> bool:
+    """Return whether a name is accepted by the strictest known provider."""
+    if not name or len(name) > MAX_FUNCTION_NAME_LENGTH:
+        return False
+    return _VALID_FUNCTION_NAME.match(name) is not None
+
+
+def sanitize_function_name(name: str, *, fallback: str = "tool") -> str:
+    """Coerce an arbitrary name into a provider-safe function name.
+
+    Args:
+        name: Untrusted name, for example one reported by an MCP server.
+        fallback: Prefix used when ``name`` cannot start a valid name on its
+            own. It must already be a valid function name.
+
+    Returns:
+        A name matching ``[A-Za-z][A-Za-z0-9_-]*`` and no longer than
+        ``MAX_FUNCTION_NAME_LENGTH``. Distinct inputs may collapse into the
+        same output; use :func:`unique_function_name` to keep aliases unique.
+    """
+    cleaned = _INVALID_FUNCTION_NAME_CHARS.sub("_", name.strip())
+    if not cleaned:
+        cleaned = fallback
+    elif not cleaned[0].isalpha():
+        cleaned = f"{fallback}_{cleaned}"
+    return cleaned[:MAX_FUNCTION_NAME_LENGTH]
+
+
+def mcp_tool_name(server_name: str, tool_name: str) -> str:
+    """Build the provider-safe name that exposes one MCP tool to the model."""
+    combined = f"{MCP_TOOL_PREFIX}{server_name.strip()}{MCP_NAME_SEPARATOR}{tool_name.strip()}"
+    return sanitize_function_name(combined, fallback="mcp")
+
+
+def is_mcp_tool_name(name: str) -> bool:
+    """Return whether a model-facing tool name belongs to an MCP server."""
+    return name.startswith(MCP_TOOL_PREFIX)
+
+
+def unique_function_name(name: str, taken: Container[str]) -> str:
+    """Return ``name``, or a numbered variant when the name is already taken."""
+    if name not in taken:
+        return name
+    suffix = 2
+    while True:
+        marker = f"_{suffix}"
+        candidate = f"{name[: MAX_FUNCTION_NAME_LENGTH - len(marker)]}{marker}"
+        if candidate not in taken:
+            return candidate
+        suffix += 1

--- a/src/amcp/progressive/tool_view.py
+++ b/src/amcp/progressive/tool_view.py
@@ -4,6 +4,11 @@ import json
 from dataclasses import dataclass
 from typing import Any
 
+from ..mcp_naming import (
+    LEGACY_MCP_TOOL_TIER_KEY,
+    MCP_TOOL_TIER_KEY,
+    is_mcp_tool_name,
+)
 from .context_budget import estimate_text_tokens
 from .relevance import RelevanceScorer, ToolTier
 from .usage_tracker import ToolUsageSnapshot
@@ -114,14 +119,16 @@ class ProgressiveToolView:
         )
 
     def _resolve_tier(self, tool_name: str, overrides: dict[str, str]) -> ToolTier:
-        raw_override = overrides.get(tool_name) or (overrides.get("mcp.*") if tool_name.startswith("mcp.") else None)
+        raw_override = overrides.get(tool_name)
+        if not raw_override and is_mcp_tool_name(tool_name):
+            raw_override = overrides.get(MCP_TOOL_TIER_KEY) or overrides.get(LEGACY_MCP_TOOL_TIER_KEY)
         if raw_override:
             try:
                 return ToolTier(raw_override)
             except ValueError:
                 pass
 
-        if tool_name.startswith("mcp."):
+        if is_mcp_tool_name(tool_name):
             return ToolTier.ON_DEMAND
 
         return DEFAULT_TOOL_TIERS.get(tool_name, ToolTier.ON_DEMAND)

--- a/src/amcp/tool_execution.py
+++ b/src/amcp/tool_execution.py
@@ -19,6 +19,10 @@ from .tools import ToolRegistry, ToolResult
 class ToolCallProtocolError(Exception):
     """Raised for provider tool-call structures that cannot be repaired."""
 
+    def __init__(self, message: str, tool_calls: Any | None = None) -> None:
+        super().__init__(message)
+        self.tool_calls = tool_calls
+
 
 class ToolPermissionError(Exception):
     """Raised when a tool call is outside the effective capability."""
@@ -90,12 +94,13 @@ class NormalizedToolCall:
     raw_arguments: str
     arguments: dict[str, Any] | None
     argument_error: str | None = None
+    extra_content: dict[str, Any] | None = None
 
 
 def normalize_tool_calls(tool_calls: Any) -> list[NormalizedToolCall]:
     """Normalize provider tool calls and classify repairable argument errors."""
     if not isinstance(tool_calls, list):
-        raise ToolCallProtocolError("Provider tool_calls must be a list")
+        raise ToolCallProtocolError("Provider tool_calls must be a list", tool_calls=tool_calls)
 
     normalized: list[NormalizedToolCall] = []
     seen_ids: set[str] = set()
@@ -107,7 +112,7 @@ def normalize_tool_calls(tool_calls: Any) -> list[NormalizedToolCall]:
         if not isinstance(call_id, str) or not call_id.strip():
             raise ToolCallProtocolError(f"Tool call {index} is missing a valid ID")
         if call_id in seen_ids:
-            raise ToolCallProtocolError(f"Duplicate tool call ID: {call_id}")
+            raise ToolCallProtocolError(f"Duplicate tool call ID: {call_id}", tool_calls=tool_calls)
         seen_ids.add(call_id)
         if not isinstance(name, str) or not name.strip():
             raise ToolCallProtocolError(f"Tool call {call_id} is missing a valid name")
@@ -145,6 +150,7 @@ def normalize_tool_calls(tool_calls: Any) -> list[NormalizedToolCall]:
                 raw_arguments=raw_arguments,
                 arguments=arguments,
                 argument_error=error,
+                extra_content=call.get("extra_content") if isinstance(call.get("extra_content"), dict) else None,
             )
         )
     return normalized

--- a/src/amcp/tool_execution.py
+++ b/src/amcp/tool_execution.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from .config import AMCPConfig
 from .mcp_client import call_mcp_tool
+from .mcp_naming import is_mcp_tool_name
 from .tools import ToolRegistry, ToolResult
 
 
@@ -183,7 +184,7 @@ class ToolExecutor:
 
         arguments = self.prepare_model_arguments(name, arguments)
         args = self._bind_arguments(name, arguments)
-        if name.startswith("mcp."):
+        if is_mcp_tool_name(name):
             return await self._execute_mcp(name, args)
         if name == "task":
             from .task import TaskTool
@@ -196,7 +197,7 @@ class ToolExecutor:
 
     def prepare_model_arguments(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         """Canonicalize model input before hooks or trusted runtime binding."""
-        if name.startswith("mcp."):
+        if is_mcp_tool_name(name):
             return dict(arguments)
         return self.registry.prepare_model_arguments(name, arguments)
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -216,6 +216,65 @@ class TestAgentToolLimits:
         assert result == "done"
 
     @pytest.mark.asyncio
+    async def test_retries_with_repaired_pairing_after_provider_pairing_error(self, tmp_path):
+        """A Gemini-style pairing 400 triggers one retry with synthesized tool results."""
+
+        pairing_error = RuntimeError(
+            "Error code: 400 - {'error': {'message': 'Please ensure that the number of "
+            "function response parts is equal to the number of function call parts of the "
+            "function call turn.', 'status': 'INVALID_ARGUMENT'}}"
+        )
+
+        class FakeLLM:
+            def __init__(self):
+                self.calls = 0
+                self.seen_messages = None
+
+            def chat(self, messages, **_kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    raise pairing_error
+                self.seen_messages = messages
+                return SimpleNamespace(content="recovered", tool_calls=None)
+
+        with patch("amcp.agent.Path.home") as mock_home, patch("amcp.agent.load_config") as mock_load:
+            mock_home.return_value = tmp_path
+            mock_load.return_value = AMCPConfig(servers={}, chat=None, context=ContextConfig())
+            agent = Agent(session_id="test-session")
+
+        llm = FakeLLM()
+        result = await agent._enhanced_chat_with_tools(
+            llm_client=llm,
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "missing",
+                            "type": "function",
+                            "function": {"name": "read_file", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "user", "content": "continue"},
+            ],
+            tools=[],
+            tool_registry={},
+            stream=False,
+            status=MagicMock(),
+            work_dir=tmp_path,
+        )
+
+        assert result == "recovered"
+        assert llm.calls == 2
+        retried_roles = [message["role"] for message in llm.seen_messages]
+        assert retried_roles == ["assistant", "tool", "user"]
+        synthesized = llm.seen_messages[1]
+        assert synthesized["tool_call_id"] == "missing"
+        assert synthesized["name"] == "read_file"
+
+    @pytest.mark.asyncio
     async def test_grep_path_is_canonicalized_before_pre_tool_hooks(self, tmp_path):
         """Hooks inspect grep's canonical paths argument rather than its alias."""
 
@@ -409,6 +468,50 @@ class TestAgentHistoryManagement:
 
 
 class TestAgentContextBudget:
+    def test_fit_tool_context_synthesizes_missing_tool_results(self):
+        messages = [
+            {"role": "system", "content": "system"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "kept",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    },
+                    {
+                        "id": "lost",
+                        "type": "function",
+                        "function": {"name": "grep", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "kept", "content": "file contents"},
+            {"role": "user", "content": "go on"},
+        ]
+
+        fitted = Agent._fit_tool_context(messages, [], 10**9)
+
+        roles = [message["role"] for message in fitted]
+        assert roles == ["system", "assistant", "tool", "tool", "user"]
+        synthesized = fitted[3]
+        assert synthesized["tool_call_id"] == "lost"
+        assert synthesized["name"] == "grep"
+        assert "synthesized" in synthesized["content"]
+        assert messages[2]["role"] == "tool" and len(messages) == 4
+
+    def test_fit_tool_context_drops_orphaned_tool_results(self):
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "tool", "tool_call_id": "orphan", "content": "stale"},
+            {"role": "user", "content": "hello"},
+        ]
+
+        fitted = Agent._fit_tool_context(messages, [], 10**9)
+
+        assert [message["role"] for message in fitted] == ["system", "user"]
+
     def test_fit_tool_context_trims_old_result_without_mutating_input(self):
         old_content = "old result " * 3000
         latest_content = "latest result " * 1000

--- a/tests/test_agent_progressive.py
+++ b/tests/test_agent_progressive.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 from amcp.agent import Agent
-from amcp.config import AMCPConfig, ChatConfig, ContextConfig
+from amcp.config import AMCPConfig, ChatConfig, ContextConfig, Server
+from amcp.mcp_naming import is_mcp_tool_name, is_valid_function_name
 
 
 @pytest.mark.asyncio
@@ -29,3 +32,44 @@ async def test_build_tools_progressive_filters_non_relevant(monkeypatch):
     assert {"read_file", "grep", "think"}.issubset(names)
     assert "task" not in names
     assert registry == {}
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_are_exposed_under_provider_safe_names(monkeypatch):
+    """MCP aliases must satisfy the strictest provider naming rule and stay reversible."""
+    cfg = AMCPConfig(
+        servers={"tavily": Server(url="https://mcp.example.com/mcp")},
+        chat=ChatConfig(model="unknown-model", mcp_tools_enabled=True),
+        context=ContextConfig(progressive_tools=False),
+    )
+    monkeypatch.setattr("amcp.agent.load_config", lambda: cfg)
+    monkeypatch.setattr(
+        "amcp.agent.list_mcp_tools",
+        AsyncMock(
+            return_value=[
+                {"name": "tavily_search", "description": "search", "inputSchema": {"type": "object"}},
+                {"name": "tavily.extract", "description": "extract", "inputSchema": {"type": "object"}},
+                {"name": "tavily extract", "description": "extract again", "inputSchema": {"type": "object"}},
+            ]
+        ),
+    )
+
+    agent = Agent()
+    tools, registry = await agent._build_tools_and_registry(user_input="search the web")
+
+    names = [tool["function"]["name"] for tool in tools]
+    assert all(is_valid_function_name(name) for name in names)
+    assert not any("." in name for name in names)
+
+    mcp_names = [name for name in names if is_mcp_tool_name(name)]
+    assert mcp_names == [
+        "mcp__tavily__tavily_search",
+        "mcp__tavily__tavily_extract",
+        "mcp__tavily__tavily_extract_2",
+    ]
+    # Aliases stay reversible so dispatch can reach the original MCP tool.
+    assert registry == {
+        "mcp__tavily__tavily_search": ("tavily", "tavily_search"),
+        "mcp__tavily__tavily_extract": ("tavily", "tavily.extract"),
+        "mcp__tavily__tavily_extract_2": ("tavily", "tavily extract"),
+    }

--- a/tests/test_execution_boundaries.py
+++ b/tests/test_execution_boundaries.py
@@ -5,13 +5,13 @@ import json
 import shutil
 from contextlib import suppress
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from amcp.agent import Agent
 from amcp.agent_spec import ResolvedAgentSpec
-from amcp.config import AMCPConfig, ContextConfig
+from amcp.config import AMCPConfig, ContextConfig, Server
 from amcp.multi_agent import AgentMode
 from amcp.tool_execution import (
     ToolCallProtocolError,
@@ -140,6 +140,33 @@ async def test_grep_does_not_repair_non_string_path(tmp_path):
     assert result.error is not None
     assert result.error.startswith("Invalid arguments:")
     assert "does not support parameter 'path'" in result.error
+
+
+@pytest.mark.asyncio
+async def test_mcp_alias_dispatches_to_the_original_tool_name(tmp_path):
+    """The sanitized alias exposed to the model maps back to the MCP server tool."""
+    alias = "mcp__tavily__tavily_extract"
+    executor = ToolExecutor(
+        context=ToolExecutionContext("session", tmp_path, "turn"),
+        capability=ToolCapability.from_spec(None, [], True),
+        exposed_tools={alias},
+        registry=create_default_tool_registry(enable_task=False),
+        mcp_registry={alias: ("tavily", "tavily.extract")},
+        config=AMCPConfig(servers={"tavily": Server(url="https://mcp.example.com/mcp")}, chat=None),
+    )
+    call_mcp_tool = AsyncMock(return_value={"content": [{"type": "text", "text": "extracted"}]})
+
+    with patch("amcp.tool_execution.call_mcp_tool", call_mcp_tool):
+        result = await executor.execute(alias, {"url": "https://example.com"})
+
+    assert result.success
+    assert result.content == "extracted"
+    server, tool_name, arguments = call_mcp_tool.await_args.args
+    assert (server.url, tool_name, arguments) == (
+        "https://mcp.example.com/mcp",
+        "tavily.extract",
+        {"url": "https://example.com"},
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -56,9 +56,9 @@ class TestHookHandler:
 
     def test_matches_regex_wildcard(self):
         """Test regex wildcard patterns."""
-        handler = HookHandler(matcher="mcp\\..*")
-        assert handler.matches("mcp.exa.search") is True
-        assert handler.matches("mcp.github.create_issue") is True
+        handler = HookHandler(matcher="mcp__.*")
+        assert handler.matches("mcp__exa__search") is True
+        assert handler.matches("mcp__github__create_issue") is True
         assert handler.matches("read_file") is False
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -88,6 +88,39 @@ class TestOpenAIClient:
         client = OpenAIClient(base_url="https://api.openai.com/v1", api_key="test-key", model="gpt-5.5")
         assert client.model == "gpt-5.5"
 
+    def test_chat_preserves_tool_call_extra_content(self):
+        client = OpenAIClient(base_url="https://api.openai.com/v1", api_key="test-key", model="gpt-5.5")
+        extra = {"google": {"thought_signature": "sig-abc"}}
+        client.client.completion = lambda **_kwargs: SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="",
+                        tool_calls=[
+                            SimpleNamespace(
+                                id="call_1",
+                                function=SimpleNamespace(name="bash", arguments='{"command": "pwd"}'),
+                                extra_content=extra,
+                            )
+                        ],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            usage=None,
+        )
+
+        response = client.chat([{"role": "user", "content": "run pwd"}])
+
+        assert response.tool_calls == [
+            {
+                "id": "call_1",
+                "name": "bash",
+                "arguments": '{"command": "pwd"}',
+                "extra_content": extra,
+            }
+        ]
+
     def test_chat_captures_provider_usage(self):
         client = OpenAIClient(base_url="https://api.openai.com/v1", api_key="test-key", model="gpt-5.5")
         client.client.completion = lambda **_kwargs: SimpleNamespace(

--- a/tests/test_mcp_naming.py
+++ b/tests/test_mcp_naming.py
@@ -1,0 +1,111 @@
+"""Tests for provider-safe tool function names."""
+
+from __future__ import annotations
+
+import pytest
+
+from amcp.mcp_naming import (
+    MAX_FUNCTION_NAME_LENGTH,
+    MCP_TOOL_PREFIX,
+    is_mcp_tool_name,
+    is_valid_function_name,
+    mcp_tool_name,
+    sanitize_function_name,
+    unique_function_name,
+)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["bash", "read_file", "mcp__tavily__tavily_search", "web-fetch", "a"],
+)
+def test_valid_function_names_are_accepted(name):
+    assert is_valid_function_name(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        "mcp.tavily.tavily_search",  # dots are rejected by Kimi/Moonshot
+        "1tool",
+        "_tool",
+        "tool name",
+        "tool:name",
+        "工具",
+        "a" * (MAX_FUNCTION_NAME_LENGTH + 1),
+    ],
+)
+def test_invalid_function_names_are_rejected(name):
+    assert not is_valid_function_name(name)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "mcp.tavily.tavily_search",
+        "  spaced name  ",
+        "9lives",
+        "_leading",
+        "tool:with/punctuation",
+        "工具",
+        "",
+        "x" * 200,
+    ],
+)
+def test_sanitize_always_returns_a_valid_name(raw):
+    assert is_valid_function_name(sanitize_function_name(raw))
+
+
+def test_sanitize_preserves_already_valid_names():
+    assert sanitize_function_name("read_file") == "read_file"
+
+
+def test_mcp_tool_name_uses_underscore_namespace():
+    name = mcp_tool_name("tavily", "tavily_search")
+
+    assert name == f"{MCP_TOOL_PREFIX}tavily__tavily_search"
+    assert is_valid_function_name(name)
+    assert is_mcp_tool_name(name)
+
+
+@pytest.mark.parametrize(
+    "server, tool",
+    [
+        ("my.server", "search.web"),
+        ("weird server", "tool@v2"),
+        ("s" * 60, "t" * 60),
+    ],
+)
+def test_mcp_tool_name_sanitizes_untrusted_parts(server, tool):
+    name = mcp_tool_name(server, tool)
+
+    assert is_valid_function_name(name)
+    assert is_mcp_tool_name(name)
+
+
+def test_builtin_names_are_not_mistaken_for_mcp_tools():
+    assert not is_mcp_tool_name("read_file")
+    assert not is_mcp_tool_name("memory")
+
+
+def test_unique_function_name_resolves_collisions():
+    taken = {"mcp__a__tool"}
+
+    first = unique_function_name("mcp__a__tool", taken)
+    taken.add(first)
+    second = unique_function_name("mcp__a__tool", taken)
+
+    assert first == "mcp__a__tool_2"
+    assert second == "mcp__a__tool_3"
+    assert is_valid_function_name(first)
+
+
+def test_unique_function_name_keeps_length_bound():
+    base = mcp_tool_name("s" * 60, "t" * 60)
+
+    candidate = unique_function_name(base, {base})
+
+    assert candidate != base
+    assert len(candidate) <= MAX_FUNCTION_NAME_LENGTH
+    assert is_valid_function_name(candidate)


### PR DESCRIPTION
# Pull Request

## Description

Fixes two provider-compatibility bugs that made multi-round tool calling fail with HTTP 400, each on a different backend family served through OpenAI-compatible endpoints.

### 1. Gemini: broken function-call/response pairing and dropped `thought_signature`

Symptom on `gmi-gemini-3.6-flash`:

```
Error code: 400 - "Please ensure that the number of function response parts is equal
to the number of function call parts of the function call turn."
```

Two root causes:

1. **Broken pairing.** Gemini strictly requires every function-call turn to be followed by exactly one function-response part per call. AMCP only normalized history inside `_fit_tool_context` when the token budget was exceeded, so any gap (stream interruption, truncated exchange, rate-limit placeholder) was sent as-is and rejected.
2. **Dropped `thought_signature`.** Gemini 3.x validates `thought_signature` on function calls. The provider returns it via OpenAI-style `extra_content`, but AMCP discarded it when building tool-call dicts in `llm.py`, so replayed history failed validation on the next turn.

Changes:

- `src/amcp/agent.py`
  - New `_repair_tool_call_pairing()`: synthesizes missing tool results and drops orphaned ones. It now runs on every request through `_fit_tool_context`, even when the history fits the budget.
  - Pairing-related 400 errors are detected by `_is_tool_call_pairing_error()` and retried once after repairing the history instead of failing the run.
  - When `normalize_tool_calls` raises `ToolCallProtocolError` for malformed calls (e.g. duplicate IDs), fall back to the raw `tool_calls` payload when it is usable instead of crashing the agent loop.
  - Assistant `tool_calls` recorded in history retain `extra_content`.
- `src/amcp/llm.py`: all four tool-call construction paths (sync/async × streaming/non-streaming) pass through `extra_content`.
- `src/amcp/tool_execution.py`: `NormalizedToolCall.extra_content` field; `ToolCallProtocolError` carries the original `tool_calls` for salvage.

### 2. Kimi: MCP tool names rejected as invalid function names

Symptom on `moonshotai/kimi-k3` (via GMI):

```
The request is invalid: Invalid request: function name is invalid, must start with
a letter and can contain letters, numbers, underscores, and dashes.
```

MCP tools were exposed as `mcp.<server>.<tool>` (e.g. `mcp.tavily.tavily_search`). Kimi/Moonshot rejects any function name outside `[A-Za-z][A-Za-z0-9_-]*`, while Gemini and GLM accept the dots — so the failure was provider-specific. It also looked history-dependent: `mcp.*` tools are `ON_DEMAND`, so they only enter the request once the grown conversation pushes their relevance over the threshold, which is why a session broke a few tool rounds in rather than on the first message.

Verified by direct requests to the same gateway: only the dotted tool name reproduces the error, while `mcp__…`, `mcp-…` and `mcp_…` spellings are accepted. Server/tool names come from the MCP server and are untrusted, so they are sanitized rather than assumed safe.

Changes:

- New `src/amcp/mcp_naming.py`: the strictest common function-name rule (`[A-Za-z][A-Za-z0-9_-]*`, ≤64 chars) plus helpers to validate, sanitize, namespace and de-duplicate model-facing names.
- MCP tools are exposed as `mcp__<server>__<tool>`, with untrusted parts sanitized and collisions numbered. The dispatch registry still maps each alias back to its original `(server, tool)` pair, so tools whose real names contain dots keep working.
- The rename is followed through MCP dispatch (`tool_execution.py`), per-conversation MCP call limits, progressive tiering (`tool_tiers` key `mcp__*`, with the legacy `mcp.*` key still honored so existing overrides do not silently stop applying), the default config, README and docs.
- `_repair_tool_call_pairing()` no longer writes an empty `name` onto synthesized tool results (an empty function name is itself rejected by strict providers), and provider `extra_content` stays on the function call rather than being copied onto the function response.

**Compatibility note:** custom agent specs that list MCP tools explicitly in `tools` / `exclude_tools` must use the new `mcp__<server>__<tool>` spelling. The `tool_tiers` wildcard accepts both spellings.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Testing

```bash
ruff format src tests
ruff check src tests
mypy src/amcp --ignore-missing-imports
python -m pytest -q -m "not llm"   # 819 passed
```

New tests cover pairing repair, pairing-error retry, `extra_content` round-tripping, malformed tool-call salvage, the function-name rules (validation, sanitization, collision numbering, length bounds), MCP alias exposure via `_build_tools_and_registry`, and alias-to-original dispatch in `ToolExecutor`.

Also verified live against the real gateways:

- `gmi-gemini-3.6-flash`: an interactive session completed 9 consecutive multi-tool-call rounds (bash, read_file, directory listing, long-history replay) without a 400, covering scenarios that previously failed on the first round.
- `gmi-kimi-k3` and `glm`: a request carrying all five `mcp__tavily__*` tools plus a multi-round tool-call history now succeeds; the same request with the old dotted names returns 400 on Kimi.

## Related Issues
<!-- Link to related issues -->
