### PR TITLE
feat: harden remote runtime reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,8 @@
 [![CI](https://github.com/tao12345666333/amcp/workflows/CI/badge.svg)](https://github.com/tao12345666333/amcp/actions)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Deploy your own on GMI Cloud](https://img.shields.io/badge/Deploy%20your%20own-GMI%20Cloud-ddea4d)](https://console.gmicloud.ai/user-console/ie/agentbox/browse-agents/amcp-agent)
-
-New to GMI Cloud? [Create an account with my referral link](https://console.gmicloud.ai/ref/KP3NWZV4).
-
-**An out-of-the-box coding-agent runtime for your terminal, server, and Telegram.**
+**A batteries-included, self-hostable, persistent coding-agent runtime for CLI, API, and
+Telegram.**
 
 AMCP is built for developers who want a useful agent immediately, not a framework they must
 assemble first. It ships with file editing, shell execution, web access, memory, skills,
@@ -22,8 +19,9 @@ agent workflows.
 
 - **Ready on the first run**: read/search/edit files, apply patches, run commands, browse the web,
   keep todos, and remember project context without installing a pile of plugins.
-- **One runtime, many surfaces**: use the same sessions from the CLI, an HTTP/WebSocket server,
-  Telegram, or cron/systemd/Kubernetes jobs.
+- **One runtime, many surfaces**: run agents through the CLI, HTTP/WebSocket API, Telegram, or
+  cron/systemd/Kubernetes jobs. Each surface supports persistent sessions; session discovery and
+  management are not yet identical across every surface.
 - **Autonomous but inspectable**: persistent sessions, request-scoped tool limits, context
   compaction, progress events, and cancellation support make long-running work easier to trust.
 - **Extensible when you need it**: add MCP servers, skills, slash commands, hooks, and custom agent
@@ -31,16 +29,24 @@ agent workflows.
 
 ## 30-second start
 
-```bash
-# Configure your model provider interactively
-uvx amcp-agent init
+Requires **Python 3.11+** and credentials for a supported model provider (or an
+OpenAI-compatible endpoint). `init` writes the provider configuration to
+`~/.config/amcp/config.toml`.
 
-# Start the coding agent in the current project
-uvx amcp-agent
+```bash
+# Install the PyPI package
+python -m pip install amcp-agent
+
+# Configure your model provider, then start in the current project
+amcp init
+amcp
 
 # Or run a single task
-uvx amcp-agent --once "summarize this repository and suggest the next test to run"
+amcp --once "summarize this repository and suggest the next test to run"
 ```
+
+The package is named `amcp-agent`. It installs the recommended `amcp` command and the
+backward-compatible `amcp-agent` command. For a no-install run, use `uvx amcp-agent`.
 
 ## What you get
 
@@ -70,9 +76,6 @@ uvx amcp-agent
 
 ```bash
 pip install amcp-agent
-
-# With Anthropic Claude support
-pip install amcp-agent[anthropic]
 
 # With Telegram bot support
 pip install amcp-agent[telegram]
@@ -117,9 +120,10 @@ amcp mcp call --server custom --tool example_tool --args '{"query":"rust async"}
 
 # HTTP/WebSocket server
 amcp serve                              # start on localhost:4096
-amcp serve --port 8080 --host 0.0.0.0   # custom host/port
+amcp serve --port 8080 --host 0.0.0.0   # requires [server.auth] configuration
 amcp serve --telegram                   # start Telegram bot alongside
 amcp attach http://localhost:4096       # connect to a running server
+amcp attach https://server.example --api-key "$AMCP_SERVER_API_KEY"
 
 # Telegram bot
 amcp telegram start                     # start polling
@@ -208,12 +212,31 @@ amcp attach http://localhost:4096  # connect from another terminal
 - `POST /api/v1/sessions/{id}/prompt` - submit a prompt and return request status
 - `POST /api/v1/sessions/{id}/prompt/stream` - submit a prompt and stream JSON-line events
 - `POST /api/v1/sessions/{id}/cancel` - cancel current session work
+- `GET /api/v1/sessions/{id}/timeline` - read durable metadata-only execution events
 - `DELETE /api/v1/sessions/{id}` - delete a session
 - `GET /api/v1/tools` - list available tools
 - `GET /api/v1/agents` - list agent types
 - `WS /ws` - WebSocket for live events
 
-Supports CORS configuration and optional server-side authentication.
+### Server authentication
+
+API authentication uses one configured API key, sent as `Authorization: Bearer <api-key>`.
+Unauthenticated operation is permitted only when the server binds to a loopback address. A
+non-loopback bind (for example `0.0.0.0`) requires authentication; configure an API key before
+exposing the service. This is transport authentication, so use TLS or a trusted reverse proxy for
+traffic that leaves the machine.
+
+Authenticated CLI clients can pass `--api-key` or set `AMCP_SERVER_API_KEY`. HTTP clients send
+`Authorization: Bearer <api-key>`; WebSocket clients may use the same header. The health endpoint
+remains public for probes.
+
+### Durable execution timeline
+
+AMCP stores a bounded per-session timeline beside each session snapshot. It records turn, tool,
+subagent task, context-compaction, provider retry/error, and token-usage metadata so interrupted
+sessions remain inspectable. Prompt content, tool arguments, tool output, and raw
+provider exception text are deliberately excluded. The newest 2,000 events are retained by
+default and can be queried with `GET /api/v1/sessions/{id}/timeline`.
 
 ## Telegram Integration
 
@@ -287,6 +310,9 @@ amcp init
 ```toml
 [chat]
 active_provider = "primary"    # optional: selected [chat.providers.<name>] profile
+request_timeout_seconds = 120
+max_retries = 2                 # transient connection, timeout, 429, and 5xx failures only
+retry_base_delay_seconds = 0.5  # exponential backoff with jitter
 mcp_tools_enabled = true
 write_tool_enabled = true
 edit_tool_enabled = true
@@ -319,7 +345,7 @@ api_type = "anthropic"
 model = "claude-model-name"
 ```
 
-Install with: `pip install amcp-agent[anthropic]`
+Anthropic support is included in the base `amcp-agent` package; no separate extra is required.
 
 ### MCP Servers
 
@@ -355,7 +381,19 @@ response_ratio = 0.30          # reserve 30% of context for response
 [server]
 host = "127.0.0.1"
 port = 4096
+
+[server.auth]
+enabled = false              # valid without a key only for loopback binds
+# api_key = "replace-with-a-secret"
 ```
+
+For a non-loopback host, set `enabled = true` and `api_key`, then send the key as a Bearer token.
+
+### Provider and deployment options
+
+[Deploy AMCP on GMI Cloud](https://console.gmicloud.ai/user-console/ie/agentbox/browse-agents/amcp-agent).
+New GMI Cloud users can optionally sign up with the maintainer's
+[referral link](https://console.gmicloud.ai/ref/KP3NWZV4) (a referral, not a requirement).
 
 ### Telegram Configuration
 
@@ -419,7 +457,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed development guidelines.
 
 - `rg` (ripgrep) must be installed and on PATH for the grep tool.
 - MCP servers must be installed separately and runnable (stdio transport).
-- The agent does not add an application-level retry around model provider failures; provider client behavior applies.
+- Foreground tool-loop model calls classify provider failures and retry transient connection,
+  timeout, rate-limit, and server errors with bounded exponential backoff. Authentication,
+  invalid-request, protocol, and streaming failures after output has started are not retried.
+  Compaction and memory-maintenance model calls currently retain their existing provider behavior.
 - Tool-call guardrails include per-request `bash` limits, output truncation for `bash`, and
   per-conversation plus per-session `read_file` limits.
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,17 +1,44 @@
 # Quick Start Guide
 
+## For Users
+
+### Prerequisites
+
+- Python 3.11 or newer
+- Credentials for a supported model provider, or access to an OpenAI-compatible endpoint
+
+### Install and run
+
+```bash
+python -m pip install amcp-agent
+amcp init
+amcp
+
+# Run one task and exit
+amcp --once "summarize this repository"
+```
+
+`amcp-agent` is the package name. Installation provides `amcp` (the recommended command) and
+`amcp-agent` (a compatibility alias). The initialization wizard stores configuration in
+`~/.config/amcp/config.toml`. Alternatively, run without installing via `uvx amcp-agent init`
+and `uvx amcp-agent`.
+
+Telegram support is optional: `python -m pip install "amcp-agent[telegram]"`. Provider support,
+including Anthropic, is included in the base package; do not install an `anthropic` extra.
+
 ## For Contributors
 
 ### 1. Clone and Setup
 ```bash
-git clone <repo-url>
-cd AMCP
+git clone https://github.com/tao12345666333/amcp.git
+cd amcp
 
 # Install with development dependencies
 pip install -e ".[dev]"
 
 # Or using uv (recommended)
-uv pip install -e ".[dev]"
+uv sync --extra dev --extra telegram
+source .venv/bin/activate
 ```
 
 ### 2. Install Pre-commit Hooks
@@ -64,28 +91,6 @@ git commit -m "feat: add new feature"
 
 # 5. Push and create PR
 git push origin feature/my-feature
-```
-
-## For Users
-
-### Installation
-```bash
-pip install amcp
-```
-
-### Basic Usage
-```bash
-# Interactive mode
-amcp
-
-# Single command
-amcp --once "create a hello.py file"
-
-# List available agents
-amcp --list
-
-# Use specific agent
-amcp --agent path/to/agent.yaml
 ```
 
 ## Common Tasks

--- a/docs/phase7-telegram-integration.md
+++ b/docs/phase7-telegram-integration.md
@@ -1,5 +1,8 @@
 # AMCP Phase 7: Telegram Integration
 
+> Historical design document. For current installation and configuration, use the
+> [README](../README.md). Some examples below describe the original design direction.
+
 Remote interaction channel for AMCP via Telegram Bot API, enabling users to command, monitor, and receive notifications from their agent on any device.
 
 ## Motivation
@@ -275,12 +278,15 @@ amcp telegram setup
 
 ## Security Considerations
 
-1. **User Whitelist**: Only explicitly allowed user IDs can interact with the bot
+1. **Access Policy**: DM and group access depends on the configured allowlist, pairing, mention,
+   open, or disabled policy
 2. **Admin Separation**: Destructive operations (config, shutdown) require admin role
-3. **Token Storage**: Bot token stored in config.toml with restricted file permissions (0600)
+3. **Token Storage**: Prefer the `TELEGRAM_BOT_TOKEN` environment variable; protect config files
+   that contain a token with appropriate operating-system permissions
 4. **Rate Limiting**: Per-user rate limits to prevent abuse
-5. **No Sensitive Data in Logs**: Bot token and user messages are not logged verbatim
-6. **Session Isolation**: Each Telegram user gets their own isolated session
+5. **Logging**: Do not expose bot tokens or credentials in logs
+6. **Session Scope**: Sessions are currently scoped by chat; authorized users in the same group
+   share that chat's agent context
 
 ## Dependencies
 
@@ -293,9 +299,9 @@ telegram = [
 
 Install with:
 ```bash
-pip install amcp[telegram]
+pip install amcp-agent[telegram]
 # or
-uv pip install amcp[telegram]
+uv pip install amcp-agent[telegram]
 ```
 
 ## Event Bus Integration

--- a/examples/README.md
+++ b/examples/README.md
@@ -322,11 +322,10 @@ To contribute new examples:
 ## 📖 Additional Resources
 
 - [AMCP Main Documentation](../README.md)
-- [Agent Configuration Guide](../docs/agents.md)
-- [Command System Guide](../docs/commands.md)
-- [Skills System Guide](../docs/skills.md)
+- [Agent Capabilities](../docs/phase2-agent-capabilities.md)
+- [Commands and Skills Guide](../docs/skills-and-commands.md)
 - [Hooks System Guide](../docs/hooks.md)
-- [Multi-Agent Workflows](../docs/multi-agent.md)
+- [Project Structure](../docs/PROJECT_STRUCTURE.md)
 
 ## 🐛 Troubleshooting
 
@@ -340,7 +339,7 @@ To contribute new examples:
 ### Getting Help
 
 - Check the [AMCP documentation](../README.md)
-- Review the [troubleshooting guide](../docs/troubleshooting.md)
+- Review the setup and notes in the [main documentation](../README.md)
 - Open an issue on the GitHub repository
 
 ---

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -124,7 +124,6 @@ When creating plugins:
 ## Learn More
 
 - [AMCP Documentation](../../README.md)
-- [Commands Guide](../../docs/commands.md)
-- [Agents Guide](../../docs/agents.md)
-- [Skills Guide](../../docs/skills.md)
+- [Commands and Skills Guide](../../docs/skills-and-commands.md)
+- [Agent Capabilities](../../docs/phase2-agent-capabilities.md)
 - [Hooks Guide](../../docs/hooks.md)

--- a/examples/workflows/data-science-workflow.md
+++ b/examples/workflows/data-science-workflow.md
@@ -2,6 +2,9 @@
 
 This workflow demonstrates how multiple agents can collaborate on a data science project, from data analysis to model deployment and documentation.
 
+> **Illustrative example:** All metrics, outputs, and readiness labels below are hypothetical
+> conversation content. They are not AMCP benchmark results or production-readiness claims.
+
 ## Workflow Overview
 
 ```
@@ -31,7 +34,9 @@ User Request → Data Scientist Agent → AI Engineer Agent → Documentation Wr
 
 **Delegation Prompt:**
 ```
-"I've developed a customer churn prediction model with 85% accuracy. Please help me optimize it for production deployment, including model optimization, API creation, and MLOps setup."
+"In this hypothetical example, I've developed a customer churn prediction model with an
+illustrative 85% accuracy. Please help me optimize it for production deployment, including model
+optimization, API creation, and MLOps setup."
 ```
 
 **AI Engineer Agent Tasks:**
@@ -225,7 +230,8 @@ Data Scientist: I'll help you build a comprehensive customer churn prediction mo
 
 [Data Scientist performs EDA, preprocessing, and model training]
 
-Data Scientist: I've developed a Random Forest model with 85% accuracy. Now I'll delegate the optimization and deployment tasks to our AI Engineer.
+Data Scientist: In this hypothetical scenario, the Random Forest model has an illustrative 85%
+accuracy. Now I'll delegate the optimization and deployment tasks to our AI Engineer.
 
 Data Scientist: /delegate ai-engineer "Please help me optimize this churn prediction model for production deployment..."
 
@@ -247,7 +253,7 @@ Data Scientist: Perfect! Your customer churn prediction system is now complete w
 ## Workflow Benefits
 
 1. **End-to-End Solution**: Complete pipeline from data to deployment
-2. **Production Ready**: Optimized for real-world usage
+2. **Deployment-oriented example**: Illustrates optimization steps for real-world usage
 3. **Comprehensive Documentation**: Self-contained with guides
 4. **Quality Assurance**: Multiple validation points
 5. **Scalable Architecture**: Ready for production scaling

--- a/examples/workflows/devops-security-workflow.md
+++ b/examples/workflows/devops-security-workflow.md
@@ -2,6 +2,10 @@
 
 This workflow demonstrates how DevOps and Security agents can collaborate to create secure, production-ready infrastructure and deployment pipelines.
 
+> **Illustrative example:** The generated configurations, compliance language, and
+> production-readiness statements below are hypothetical workflow output. They are not audited,
+> certified, or evidence that AMCP itself meets a compliance or production benchmark.
+
 ## Workflow Overview
 
 ```
@@ -388,8 +392,8 @@ DevOps Engineer: Perfect! Your secure CI/CD pipeline is now complete with all se
 ## Workflow Benefits
 
 1. **Security First**: Built-in security at every layer
-2. **Compliance Ready**: Meets common security standards
-3. **Production Ready**: Scalable and reliable infrastructure
+2. **Compliance-oriented example**: Illustrates checks that still require expert validation
+3. **Deployment-oriented example**: Illustrates scalable infrastructure patterns
 4. **Comprehensive Documentation**: Complete operational guides
 5. **Automated Security**: Continuous security validation
 

--- a/src/amcp/agent.py
+++ b/src/amcp/agent.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import random
 import time
 import uuid
 from collections.abc import Callable
@@ -34,6 +35,7 @@ from .hooks import (
     run_pre_tool_use_hooks,
     run_user_prompt_hooks,
 )
+from .llm import ProviderError, classify_provider_error
 from .mcp_client import list_mcp_tools
 from .mcp_naming import is_mcp_tool_name, mcp_tool_name, unique_function_name
 from .memory import get_memory_manager
@@ -49,7 +51,7 @@ from .project_rules import ProjectRulesLoader
 from .runtime import CancellationResult, RuntimeClosedError, SessionRuntime, TurnCancelledError, TurnHandle, TurnRequest
 from .session_search import get_transcript_store
 from .session_state import CompactionCheckpoint, SessionState
-from .session_store import SessionStore
+from .session_store import SessionStore, SessionTimelineStore
 from .skills import get_skill_manager
 from .tool_execution import (
     ToolCallProtocolError,
@@ -141,8 +143,13 @@ def _repair_tool_call_pairing(messages: list[dict[str, Any]]) -> list[dict[str, 
 
 def _is_tool_call_pairing_error(error: Exception) -> bool:
     """Check whether an error is a provider-side tool-call pairing rejection."""
-    text = str(error).lower()
-    return "function response parts" in text or ("function call" in text and "invalid_argument" in text)
+    current: BaseException | None = error
+    while current is not None:
+        text = str(current).lower()
+        if "function response parts" in text or ("function call" in text and "invalid_argument" in text):
+            return True
+        current = current.__cause__
+    return False
 
 
 class BusyError(Exception):
@@ -178,6 +185,10 @@ class Agent:
         self.conversation_history: list[dict[str, Any]] = []
         self._session_store = SessionStore(
             Path.home() / ".config" / "amcp" / "sessions",
+            self.session_id,
+        )
+        self._timeline_store = SessionTimelineStore(
+            self._session_store.root,
             self.session_id,
         )
         self.session_file = self._session_store.path
@@ -376,6 +387,15 @@ class Agent:
             "session_file": str(self.session_file),
         }
 
+    def get_timeline(self, *, limit: int = 100) -> list[dict[str, Any]]:
+        """Return recent durable execution events for this session."""
+        return self._timeline_store.read(limit=limit)
+
+    def delete_persisted_session(self) -> None:
+        """Delete the durable conversation snapshot and execution timeline."""
+        self._session_store.delete()
+        self._timeline_store.delete()
+
     def get_token_usage_summary(self) -> dict[str, Any]:
         """Return current context usage and provider-reported session totals."""
         context_window = self.last_context_window
@@ -441,6 +461,15 @@ class Agent:
             "timestamp": datetime.now().isoformat(),
             **data,
         }
+        if event_type.startswith(("turn.", "tool.", "provider.", "llm.", "context.", "memory.")):
+            try:
+                self._timeline_store.append(
+                    event_type,
+                    data,
+                    timestamp=event_data["timestamp"],
+                )
+            except Exception as exc:
+                logger.debug("Timeline persistence failed (non-critical): %s", exc)
         for callback in self._event_callbacks:
             with contextlib.suppress(Exception):
                 callback(event_type, event_data)
@@ -814,13 +843,15 @@ class Agent:
         )
 
     def _on_runtime_event(self, event: str, handle: TurnHandle) -> None:
-        self._emit_event(
-            event,
-            {
-                "turn_id": handle.id,
-                "turn_status": handle.status.value,
-            },
-        )
+        data: dict[str, Any] = {
+            "turn_id": handle.id,
+            "turn_status": handle.status.value,
+        }
+        outcome = handle.outcome
+        if outcome and isinstance(outcome.error, ProviderError):
+            data["error_kind"] = outcome.error.kind.value
+            data["status_code"] = outcome.error.status_code
+        self._emit_event(event, data)
 
     async def _process_message(self, user_input: str, work_dir: Path | None, stream: bool, show_progress: bool) -> str:
         """
@@ -937,6 +968,13 @@ class Agent:
                             original_tokens=compaction_result.original_tokens,
                             compacted_tokens=compaction_result.compacted_tokens,
                         )
+                        self._emit_event(
+                            "context.compacted",
+                            {
+                                "input_tokens": compaction_result.original_tokens,
+                                "output_tokens": compaction_result.compacted_tokens,
+                            },
+                        )
                         history_to_add = draft.model_context(turn_messages)
                         self.reset_memory_context_snapshot()
                         self.console.print("[dim]Context compacted to reduce token usage[/dim]")
@@ -1003,7 +1041,7 @@ class Agent:
         except asyncio.CancelledError:
             self._apply_session_state(committed_state)
             raise
-        except (AgentExecutionError, MaxStepsReached, ToolCallProtocolError):
+        except (AgentExecutionError, MaxStepsReached, ProviderError, ToolCallProtocolError):
             self._apply_session_state(committed_state)
             raise
         except Exception as e:
@@ -1530,10 +1568,7 @@ class Agent:
 
         for step in range(max_steps):
             self.step_count = step + 1
-            # Update LLM call counters (both per-request and session total)
-            self.current_request_llm_calls += 1
-            self.total_llm_calls += 1
-            status.update(f"[bold]Agent {self.name}[/bold] - LLM Call {self.current_request_llm_calls}")
+            status.update(f"[bold]Agent {self.name}[/bold] - LLM Call {self.current_request_llm_calls + 1}")
 
             # Define stream callback if streaming is enabled
             stream_callback = None
@@ -1552,8 +1587,11 @@ class Agent:
                     messages=messages,
                     tools=tools,
                     stream_callback=stream_callback,
+                    cfg=cfg.chat,
                 )
             except Exception as call_error:
+                if isinstance(call_error, ProviderError) and call_error.partial_output:
+                    raise
                 if not _is_tool_call_pairing_error(call_error):
                     raise
                 logger.warning(
@@ -1567,6 +1605,7 @@ class Agent:
                     messages=messages,
                     tools=tools,
                     stream_callback=stream_callback,
+                    cfg=cfg.chat,
                 )
             self._record_llm_usage(resp, estimated_input_tokens, context_window)
 
@@ -1634,11 +1673,13 @@ class Agent:
                     )
                     # Get a final response from the LLM with the current messages
                     try:
-                        self.current_request_llm_calls += 1
-                        self.total_llm_calls += 1
                         messages = self._fit_tool_context(messages, [], input_token_budget)
                         estimated_input_tokens = estimate_request_tokens(messages)
-                        final_resp = await self._call_llm(llm_client, messages=messages)
+                        final_resp = await self._call_llm(
+                            llm_client,
+                            messages=messages,
+                            cfg=cfg.chat,
+                        )
                         self._record_llm_usage(final_resp, estimated_input_tokens, context_window)
                         final_text = final_resp.content or ""
                         status.update(f"[bold]Agent {self.name}[/bold] - ✅ Complete")
@@ -1900,28 +1941,82 @@ class Agent:
         status.update(f"[bold]Agent {self.name}[/bold] - ⚠️ Max steps reached")
         raise MaxStepsReached(self.max_steps)
 
-    @staticmethod
     async def _call_llm(
+        self,
         llm_client: Any,
         *,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
         stream_callback: Any | None = None,
+        cfg: ChatConfig | None = None,
     ) -> Any:
-        """Call native async providers and adapt legacy synchronous test clients."""
-        async_chat = getattr(llm_client, "achat", None)
-        if callable(async_chat):
-            return await async_chat(
+        """Call a provider with timeout and bounded transient-error retries."""
+        policy = cfg or ChatConfig()
+        timeout = max(0.1, float(policy.request_timeout_seconds))
+        max_retries = max(0, int(policy.max_retries))
+        base_delay = max(0.0, float(policy.retry_base_delay_seconds))
+        emitted_output = False
+
+        def tracked_callback(chunk: str) -> None:
+            nonlocal emitted_output
+            emitted_output = True
+            if stream_callback is not None:
+                stream_callback(chunk)
+
+        callback = tracked_callback if stream_callback is not None else None
+
+        async def call_once() -> Any:
+            async_chat = getattr(llm_client, "achat", None)
+            if callable(async_chat):
+                return await async_chat(
+                    messages=messages,
+                    tools=tools,
+                    stream_callback=callback,
+                )
+            return await asyncio.to_thread(
+                llm_client.chat,
                 messages=messages,
                 tools=tools,
-                stream_callback=stream_callback,
+                stream_callback=callback,
             )
-        return await asyncio.to_thread(
-            llm_client.chat,
-            messages=messages,
-            tools=tools,
-            stream_callback=stream_callback,
-        )
+
+        for attempt in range(max_retries + 1):
+            try:
+                self.current_request_llm_calls += 1
+                self.total_llm_calls += 1
+                return await asyncio.wait_for(call_once(), timeout=timeout)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                provider_error = classify_provider_error(exc, partial_output=emitted_output)
+                if not provider_error.retryable or attempt >= max_retries:
+                    self._emit_event(
+                        "provider.error",
+                        {
+                            "error_kind": provider_error.kind.value,
+                            "status_code": provider_error.status_code,
+                            "partial_output": provider_error.partial_output,
+                            "attempt": attempt + 1,
+                        },
+                    )
+                    raise provider_error from exc
+
+                retry_delay = provider_error.retry_after
+                if retry_delay is None:
+                    retry_delay = random.uniform(0.0, min(30.0, base_delay * (2**attempt)))
+                retry_delay = min(retry_delay, 60.0)
+                self._emit_event(
+                    "provider.retry",
+                    {
+                        "error_kind": provider_error.kind.value,
+                        "status_code": provider_error.status_code,
+                        "attempt": attempt + 2,
+                        "delay_seconds": retry_delay,
+                    },
+                )
+                await asyncio.sleep(retry_delay)
+
+        raise AssertionError("provider retry loop exhausted without returning or raising")
 
     def _record_llm_usage(
         self,
@@ -1938,6 +2033,15 @@ class Agent:
             self.last_usage_from_api = False
             self.total_input_tokens += estimated_input_tokens
             self.estimated_input_llm_calls += 1
+            self._emit_event(
+                "llm.usage",
+                {
+                    "input_tokens": estimated_input_tokens,
+                    "output_tokens": None,
+                    "context_window": context_window,
+                    "usage_from_api": False,
+                },
+            )
             return
 
         self.last_context_tokens = usage.prompt_tokens
@@ -1948,6 +2052,17 @@ class Agent:
         self.total_cached_input_tokens += usage.cached_input_tokens
         self.total_cache_write_input_tokens += usage.cache_write_input_tokens
         self.usage_reported_llm_calls += 1
+        self._emit_event(
+            "llm.usage",
+            {
+                "input_tokens": usage.prompt_tokens,
+                "output_tokens": usage.output_tokens,
+                "cached_input_tokens": usage.cached_input_tokens,
+                "total_tokens": usage.total_tokens,
+                "context_window": context_window,
+                "usage_from_api": True,
+            },
+        )
 
     @staticmethod
     def _fit_tool_context(

--- a/src/amcp/cli.py
+++ b/src/amcp/cli.py
@@ -285,6 +285,18 @@ def serve_command(
     Deploy with Docker or systemd for production.
     """
     from .server import run_server
+    from .server.config import AuthConfig as RuntimeAuthConfig
+
+    cfg = load_config()
+    configured_auth = cfg.server.auth if cfg.server else None
+    runtime_auth = (
+        RuntimeAuthConfig(
+            enabled=configured_auth.enabled,
+            api_key=configured_auth.api_key,
+        )
+        if configured_auth
+        else RuntimeAuthConfig()
+    )
 
     if telegram_enabled:
         _start_telegram_bot(work_dir)
@@ -296,6 +308,7 @@ def serve_command(
         port=port,
         work_dir=str(work_dir) if work_dir else None,
         reload=reload,
+        auth=runtime_auth,
     )
 
 
@@ -364,6 +377,14 @@ def attach_command(
             readable=True,
         ),
     ] = None,
+    api_key: Annotated[
+        str | None,
+        typer.Option(
+            "--api-key",
+            help="Server API key (or set AMCP_SERVER_API_KEY)",
+            envvar="AMCP_SERVER_API_KEY",
+        ),
+    ] = None,
 ) -> None:
     """Connect to a running AMCP server and interact with it.
 
@@ -376,13 +397,14 @@ def attach_command(
         amcp attach http://localhost:4096 -w /path/to/project
     """
     # Use synchronous implementation to avoid event loop issues
-    _attach_sync(url, session_id, work_dir)
+    _attach_sync(url, session_id, work_dir, api_key)
 
 
 def _attach_sync(
     url: str,
     session_id: str | None,
     work_dir: Path | None,
+    api_key: str | None = None,
 ) -> None:
     """Synchronous implementation of attach command using httpx directly.
 
@@ -393,10 +415,11 @@ def _attach_sync(
     from prompt_toolkit.history import FileHistory
 
     base_url = url.rstrip("/")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
 
     # Check server health
     try:
-        with httpx.Client(timeout=5.0) as http:
+        with httpx.Client(timeout=5.0, headers=headers) as http:
             health_resp = http.get(f"{base_url}/api/v1/health")
             health_resp.raise_for_status()
             health = health_resp.json()
@@ -407,7 +430,7 @@ def _attach_sync(
 
     # Create or get session
     try:
-        with httpx.Client(timeout=30.0) as http:
+        with httpx.Client(timeout=30.0, headers=headers) as http:
             if session_id:
                 # Try to get existing session
                 try:
@@ -476,7 +499,7 @@ def _attach_sync(
 
             if user_input.lower() in {"/new", "/session new"}:
                 try:
-                    with httpx.Client(timeout=30.0) as http:
+                    with httpx.Client(timeout=30.0, headers=headers) as http:
                         sess_resp = http.post(
                             f"{base_url}/api/v1/sessions",
                             json={"cwd": str(work_dir) if work_dir else None},
@@ -493,7 +516,7 @@ def _attach_sync(
             if user_input.lower().startswith("/session switch "):
                 target_session_id = user_input.split(maxsplit=2)[2].strip()
                 try:
-                    with httpx.Client(timeout=10.0) as http:
+                    with httpx.Client(timeout=10.0, headers=headers) as http:
                         resp = http.get(f"{base_url}/api/v1/sessions/{target_session_id}")
                         resp.raise_for_status()
                         session_id = target_session_id
@@ -505,7 +528,7 @@ def _attach_sync(
 
             if user_input.lower() == "/cancel":
                 try:
-                    with httpx.Client(timeout=5.0) as http:
+                    with httpx.Client(timeout=5.0, headers=headers) as http:
                         http.post(f"{base_url}/api/v1/sessions/{session_id}/cancel")
                         console.print("[green]Cancel request sent.[/green]")
                 except Exception as e:
@@ -514,7 +537,7 @@ def _attach_sync(
                 continue
 
             if user_input.lower() == "/sessions":
-                with httpx.Client(timeout=10.0) as http:
+                with httpx.Client(timeout=10.0, headers=headers) as http:
                     resp = http.get(f"{base_url}/api/v1/sessions")
                     sessions = resp.json()
                     console.print("[bold]Sessions:[/bold]")
@@ -525,7 +548,7 @@ def _attach_sync(
                 continue
 
             if user_input.lower() == "/info":
-                with httpx.Client(timeout=10.0) as http:
+                with httpx.Client(timeout=10.0, headers=headers) as http:
                     resp = http.get(f"{base_url}/api/v1/sessions/{session_id}")
                     session_info = resp.json()
                     console.print("[bold]Session Info:[/bold]")
@@ -537,7 +560,7 @@ def _attach_sync(
                 continue
 
             if user_input.lower() == "/tools":
-                with httpx.Client(timeout=10.0) as http:
+                with httpx.Client(timeout=10.0, headers=headers) as http:
                     resp = http.get(f"{base_url}/api/v1/tools")
                     tools_data = resp.json()
                     tools = tools_data.get("tools", [])
@@ -550,7 +573,7 @@ def _attach_sync(
                 continue
 
             if user_input.lower() == "/agents":
-                with httpx.Client(timeout=10.0) as http:
+                with httpx.Client(timeout=10.0, headers=headers) as http:
                     resp = http.get(f"{base_url}/api/v1/agents")
                     agents_data = resp.json()
                     agents = agents_data.get("agents", [])
@@ -563,7 +586,7 @@ def _attach_sync(
             # Send prompt to server with streaming
             try:
                 with (
-                    httpx.Client(timeout=300.0) as http,
+                    httpx.Client(timeout=300.0, headers=headers) as http,
                     http.stream(
                         "POST",
                         f"{base_url}/api/v1/sessions/{session_id}/prompt/stream",
@@ -623,8 +646,11 @@ def _attach_sync(
                                 )
                             )
                             try:
-                                with httpx.Client(timeout=5.0) as cancel_http:
-                                    cancel_http.post(f"{base_url}/api/v1/sessions/{session_id}/cancel")
+                                with httpx.Client(timeout=5.0, headers=headers) as cancel_http:
+                                    cancel_response = cancel_http.post(
+                                        f"{base_url}/api/v1/sessions/{session_id}/cancel"
+                                    )
+                                    cancel_response.raise_for_status()
                                     console.print("\n[yellow]Operation cancelled.[/yellow]")
                             except Exception as e:
                                 console.print(f"\n[red]Failed to send cancel request: {e}[/red]")

--- a/src/amcp/client/__init__.py
+++ b/src/amcp/client/__init__.py
@@ -83,6 +83,8 @@ class AMCPClient:
         timeout: float = 30.0,
         retry_attempts: int = 3,
         mode: ClientMode | None = None,
+        headers: dict[str, str] | None = None,
+        api_key: str | None = None,
     ):
         """Initialize the AMCP client.
 
@@ -91,11 +93,15 @@ class AMCPClient:
             timeout: Default timeout in seconds.
             retry_attempts: Number of retry attempts for failed requests.
             mode: Explicit mode selection. If None, auto-detects.
+            headers: Optional custom remote request headers.
+            api_key: Optional remote server API key.
         """
         self._url = url
         self._timeout = timeout
         self._retry_attempts = retry_attempts
         self._mode = mode or (ClientMode.REMOTE if url else ClientMode.EMBEDDED)
+        self._headers = headers
+        self._api_key = api_key
         self._client: BaseClient | None = None
         self._ws_client: WebSocketClient | None = None
 
@@ -167,6 +173,8 @@ class AMCPClient:
                 url=self._url,
                 timeout=self._timeout,
                 retry_attempts=self._retry_attempts,
+                headers=self._headers,
+                api_key=self._api_key,
             )
         else:
             # Embedded mode - import here to avoid circular imports
@@ -316,6 +324,8 @@ class AMCPClient:
         ws_client = WebSocketClient(
             url=self._url,
             session_id=session_id,
+            headers=self._headers,
+            api_key=self._api_key,
         )
         await ws_client.connect()
         return ws_client

--- a/src/amcp/client/http_client.py
+++ b/src/amcp/client/http_client.py
@@ -40,6 +40,7 @@ class HTTPClient(BaseClient):
         timeout: float = 30.0,
         retry_attempts: int = 3,
         headers: dict[str, str] | None = None,
+        api_key: str | None = None,
     ):
         """Initialize the HTTP client.
 
@@ -48,11 +49,14 @@ class HTTPClient(BaseClient):
             timeout: Default timeout in seconds.
             retry_attempts: Number of retry attempts for failed requests.
             headers: Optional custom headers.
+            api_key: Optional API key sent as a Bearer token.
         """
         self._url = url.rstrip("/")
         self._timeout = timeout
         self._retry_attempts = retry_attempts
-        self._headers = headers or {}
+        self._headers = dict(headers or {})
+        if api_key is not None and not any(key.lower() == "authorization" for key in self._headers):
+            self._headers["Authorization"] = f"Bearer {api_key}"
         self._client: httpx.AsyncClient | None = None
 
     @property

--- a/src/amcp/client/ws_client.py
+++ b/src/amcp/client/ws_client.py
@@ -12,6 +12,7 @@ import uuid
 from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Any
+from urllib.parse import urlencode
 
 import websockets
 from websockets.exceptions import ConnectionClosed, WebSocketException
@@ -40,6 +41,8 @@ class WebSocketClient:
         session_id: str | None = None,
         *,
         timeout: float = 30.0,
+        headers: dict[str, str] | None = None,
+        api_key: str | None = None,
     ):
         """Initialize the WebSocket client.
 
@@ -47,10 +50,15 @@ class WebSocketClient:
             url: Server URL (HTTP URL will be converted to WS).
             session_id: Optional session ID to bind to.
             timeout: Connection timeout in seconds.
+            headers: Optional WebSocket handshake headers.
+            api_key: Optional API key sent as a Bearer token.
         """
         self._url = url.rstrip("/")
         self._session_id = session_id
         self._timeout = timeout
+        self._headers = dict(headers or {})
+        if api_key is not None and not any(key.lower() == "authorization" for key in self._headers):
+            self._headers["Authorization"] = f"Bearer {api_key}"
         self._ws: Any = None  # websockets.WebSocketClientProtocol
         self._message_queue: asyncio.Queue[dict] = asyncio.Queue()
         self._receive_task: asyncio.Task | None = None
@@ -68,7 +76,7 @@ class WebSocketClient:
 
         ws_url = f"{url}/ws"
         if self._session_id:
-            ws_url += f"?session_id={self._session_id}"
+            ws_url += "?" + urlencode({"session_id": self._session_id})
         return ws_url
 
     @property
@@ -84,7 +92,7 @@ class WebSocketClient:
         """
         try:
             self._ws = await asyncio.wait_for(
-                websockets.connect(self.ws_url),
+                websockets.connect(self.ws_url, additional_headers=self._headers),
                 timeout=self._timeout,
             )
 

--- a/src/amcp/config.py
+++ b/src/amcp/config.py
@@ -67,6 +67,9 @@ class ChatProviderConfig:
     api_key: str | None = None
     api_type: str | None = None  # any-llm provider ID, or "openai_responses"
     model_config: ModelConfig | None = None
+    request_timeout_seconds: float | None = None
+    max_retries: int | None = None
+    retry_base_delay_seconds: float | None = None
 
 
 @dataclass
@@ -78,6 +81,12 @@ class ChatConfig:
 
     # Model configuration (from models.dev or custom)
     model_config: ModelConfig | None = None
+
+    # Provider reliability policy. Retries are only attempted for transient
+    # failures and never after a streaming response emitted content.
+    request_timeout_seconds: float = 120.0
+    max_retries: int = 2
+    retry_base_delay_seconds: float = 0.5
 
     # Named provider profiles. ``active_provider`` selects which profile is copied
     # into the top-level chat fields at load time so existing call sites keep working.
@@ -346,6 +355,9 @@ def _decode_chat_provider(raw: Mapping[str, object]) -> ChatProviderConfig:
     model = raw.get("model")
     api_key = raw.get("api_key")
     api_type = raw.get("api_type")
+    request_timeout_seconds = raw.get("request_timeout_seconds")
+    max_retries = raw.get("max_retries")
+    retry_base_delay_seconds = raw.get("retry_base_delay_seconds")
     raw_model_config = raw.get("model_config")
     model_config = _decode_model_config(raw_model_config) if isinstance(raw_model_config, dict) else None
     return ChatProviderConfig(
@@ -354,6 +366,11 @@ def _decode_chat_provider(raw: Mapping[str, object]) -> ChatProviderConfig:
         api_key=str(api_key) if api_key is not None else None,
         api_type=str(api_type) if api_type is not None else None,
         model_config=model_config,
+        request_timeout_seconds=(float(str(request_timeout_seconds)) if request_timeout_seconds is not None else None),
+        max_retries=int(str(max_retries)) if max_retries is not None else None,
+        retry_base_delay_seconds=(
+            float(str(retry_base_delay_seconds)) if retry_base_delay_seconds is not None else None
+        ),
     )
 
 
@@ -378,6 +395,12 @@ def _apply_active_provider(chat: ChatConfig) -> ChatConfig:
         )
     chat.api_type = provider.api_type
     chat.model_config = provider.model_config
+    if provider.request_timeout_seconds is not None:
+        chat.request_timeout_seconds = provider.request_timeout_seconds
+    if provider.max_retries is not None:
+        chat.max_retries = provider.max_retries
+    if provider.retry_base_delay_seconds is not None:
+        chat.retry_base_delay_seconds = provider.retry_base_delay_seconds
     return chat
 
 
@@ -388,6 +411,9 @@ def _decode_chat(raw: Mapping[str, object] | None) -> ChatConfig | None:
     model = raw.get("model")
     api_key = raw.get("api_key")
     api_type = raw.get("api_type")
+    request_timeout_seconds = raw.get("request_timeout_seconds", 120.0)
+    max_retries = raw.get("max_retries", 2)
+    retry_base_delay_seconds = raw.get("retry_base_delay_seconds", 0.5)
     tool_loop_limit = raw.get("tool_loop_limit")
     bash_tool_limit = raw.get("bash_tool_limit")
     default_max_lines = raw.get("default_max_lines")
@@ -419,6 +445,9 @@ def _decode_chat(raw: Mapping[str, object] | None) -> ChatConfig | None:
         api_key=str(api_key) if api_key is not None else None,
         api_type=str(api_type) if api_type is not None else None,
         model_config=model_config,
+        request_timeout_seconds=float(str(request_timeout_seconds)),
+        max_retries=int(str(max_retries)),
+        retry_base_delay_seconds=float(str(retry_base_delay_seconds)),
         active_provider=str(active_provider) if active_provider is not None else None,
         providers=providers,
         tool_loop_limit=int(str(tool_loop_limit)) if tool_loop_limit is not None else None,
@@ -687,6 +716,12 @@ def _encode_chat_provider(p: ChatProviderConfig) -> dict:
         out["api_key"] = p.api_key
     if p.api_type:
         out["api_type"] = p.api_type
+    if p.request_timeout_seconds is not None:
+        out["request_timeout_seconds"] = float(p.request_timeout_seconds)
+    if p.max_retries is not None:
+        out["max_retries"] = int(p.max_retries)
+    if p.retry_base_delay_seconds is not None:
+        out["retry_base_delay_seconds"] = float(p.retry_base_delay_seconds)
     model_config_dict = _encode_model_config(p.model_config)
     if model_config_dict:
         out["model_config"] = model_config_dict
@@ -706,6 +741,9 @@ def _encode_chat(c: ChatConfig | None) -> dict | None:
         out["api_key"] = c.api_key
     if c.api_type and not provider_profiles_enabled:
         out["api_type"] = c.api_type
+    out["request_timeout_seconds"] = float(c.request_timeout_seconds)
+    out["max_retries"] = int(c.max_retries)
+    out["retry_base_delay_seconds"] = float(c.retry_base_delay_seconds)
     # Model config
     model_config_dict = _encode_model_config(c.model_config)
     if model_config_dict and not provider_profiles_enabled:

--- a/src/amcp/event_bus.py
+++ b/src/amcp/event_bus.py
@@ -639,11 +639,22 @@ async def emit_task_event(
     **data: Any,
 ) -> None:
     """Emit a task event."""
-    await get_event_bus().emit(
-        Event(
-            type=event_type,
-            source=f"task:{task_id}",
-            session_id=session_id,
-            data={"task_id": task_id, "description": task_description, **data},
-        )
+    event = Event(
+        type=event_type,
+        source=f"task:{task_id}",
+        session_id=session_id,
+        data={"task_id": task_id, "description": task_description, **data},
     )
+    await get_event_bus().emit(event)
+    if session_id:
+        try:
+            from pathlib import Path
+
+            from .session_store import SessionTimelineStore
+
+            SessionTimelineStore(
+                Path.home() / ".config" / "amcp" / "sessions",
+                session_id,
+            ).append(event_type.value, event.data, timestamp=event.timestamp.isoformat())
+        except Exception as exc:
+            logger.debug("Task timeline persistence failed (non-critical): %s", exc)

--- a/src/amcp/llm.py
+++ b/src/amcp/llm.py
@@ -7,13 +7,143 @@ import os
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any, cast
+
+import httpx
 
 from .config import ChatConfig
 
 # Type aliases for commonly used complex types
 ToolCall = dict[str, Any]
 Message = dict[str, Any]
+
+
+class ProviderErrorKind(StrEnum):
+    """Stable categories for failures returned by model providers."""
+
+    AUTH = "auth"
+    RATE_LIMIT = "rate_limit"
+    TIMEOUT = "timeout"
+    CONNECTION = "connection"
+    SERVER = "server"
+    INVALID_REQUEST = "invalid_request"
+    PROTOCOL = "protocol"
+    UNKNOWN = "unknown"
+
+
+class ProviderError(RuntimeError):
+    """A safe, structured provider failure suitable for transport responses."""
+
+    def __init__(
+        self,
+        kind: ProviderErrorKind,
+        *,
+        status_code: int | None = None,
+        retry_after: float | None = None,
+        retryable: bool = False,
+        partial_output: bool = False,
+    ):
+        self.kind = kind
+        self.status_code = status_code
+        self.retry_after = retry_after
+        self.retryable = retryable
+        self.partial_output = partial_output
+        status = f" (HTTP {status_code})" if status_code is not None else ""
+        messages = {
+            ProviderErrorKind.AUTH: "Model provider authentication failed",
+            ProviderErrorKind.RATE_LIMIT: "Model provider rate limit was exceeded",
+            ProviderErrorKind.TIMEOUT: "Model provider request timed out",
+            ProviderErrorKind.CONNECTION: "Could not connect to the model provider",
+            ProviderErrorKind.SERVER: "Model provider is temporarily unavailable",
+            ProviderErrorKind.INVALID_REQUEST: "Model provider rejected the request",
+            ProviderErrorKind.PROTOCOL: "Model provider returned an invalid response",
+            ProviderErrorKind.UNKNOWN: "Model provider request failed",
+        }
+        super().__init__(messages[kind] + status)
+
+
+def _provider_status_code(error: BaseException) -> int | None:
+    """Extract an HTTP status code from common provider SDK exception shapes."""
+    direct = getattr(error, "status_code", None)
+    response = getattr(error, "response", None)
+    value = direct if direct is not None else getattr(response, "status_code", None)
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _provider_retry_after(error: BaseException) -> float | None:
+    """Extract a numeric Retry-After value when exposed by an SDK response."""
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    value = headers.get("retry-after") or headers.get("Retry-After")
+    try:
+        return max(0.0, float(value)) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def classify_provider_error(error: BaseException, *, partial_output: bool = False) -> ProviderError:
+    """Classify an arbitrary provider SDK exception without exposing its message."""
+    if isinstance(error, ProviderError):
+        if partial_output and not error.partial_output:
+            error.partial_output = True
+            error.retryable = False
+        return error
+
+    chain: list[BaseException] = []
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen and len(chain) < 8:
+        seen.add(id(current))
+        chain.append(current)
+        nested = getattr(current, "original_exception", None)
+        current = nested if isinstance(nested, BaseException) else current.__cause__
+
+    status = next((code for item in chain if (code := _provider_status_code(item)) is not None), None)
+    names = " ".join(type(item).__name__.lower() for item in chain)
+    text = " ".join(str(item).lower() for item in chain)
+    if status in {401, 403} or "authentication" in names or "permissiondenied" in names:
+        kind = ProviderErrorKind.AUTH
+    elif status == 429 or "ratelimit" in names or "rate limit" in text:
+        kind = ProviderErrorKind.RATE_LIMIT
+    elif any(isinstance(item, (TimeoutError, asyncio.TimeoutError, httpx.TimeoutException)) for item in chain) or (
+        "timeout" in names
+    ):
+        kind = ProviderErrorKind.TIMEOUT
+    elif any(isinstance(item, (ConnectionError, httpx.NetworkError)) for item in chain) or any(
+        marker in names for marker in ("connection", "connecterror", "networkerror")
+    ):
+        kind = ProviderErrorKind.CONNECTION
+    elif status is not None and status >= 500:
+        kind = ProviderErrorKind.SERVER
+    elif status is not None and 400 <= status < 500:
+        kind = ProviderErrorKind.INVALID_REQUEST
+    elif any(isinstance(item, (ValueError, TypeError)) for item in chain):
+        kind = ProviderErrorKind.PROTOCOL
+    else:
+        kind = ProviderErrorKind.UNKNOWN
+
+    retryable = kind in {
+        ProviderErrorKind.RATE_LIMIT,
+        ProviderErrorKind.TIMEOUT,
+        ProviderErrorKind.CONNECTION,
+        ProviderErrorKind.SERVER,
+    }
+    return ProviderError(
+        kind,
+        status_code=status,
+        retry_after=next(
+            (value for item in chain if (value := _provider_retry_after(item)) is not None),
+            None,
+        ),
+        retryable=retryable and not partial_output,
+        partial_output=partial_output,
+    )
 
 
 def _extract_think_tags(content: str) -> tuple[str | None, str]:
@@ -210,7 +340,13 @@ class AnyLLMClient(BaseLLMClient):
     ):
         from any_llm import AnyLLM
 
-        self.client = AnyLLM.create(provider, api_key=api_key, api_base=base_url)
+        client_options = {"max_retries": 0} if provider in {"anthropic", "gmi", "openai"} else {}
+        self.client = AnyLLM.create(
+            provider,
+            api_key=api_key,
+            api_base=base_url,
+            **client_options,
+        )
         self.provider = provider
         self.model = model
 
@@ -493,7 +629,12 @@ class OpenAIResponsesClient(BaseLLMClient):
     def __init__(self, base_url: str, api_key: str | None, model: str):
         from any_llm import AnyLLM
 
-        self.client = AnyLLM.create("openai", api_key=api_key, api_base=base_url)
+        self.client = AnyLLM.create(
+            "openai",
+            api_key=api_key,
+            api_base=base_url,
+            max_retries=0,
+        )
         self.model = model
 
     def chat(

--- a/src/amcp/server/app.py
+++ b/src/amcp/server/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import secrets
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -11,7 +12,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from .._version import __version__
-from .config import ServerConfig, get_server_config, set_server_config
+from ..llm import ProviderError, ProviderErrorKind
+from .config import AuthConfig, ServerConfig, get_server_config, set_server_config
 from .events import router as events_router
 from .routes import agents_router, health_router, sessions_router, tools_router
 from .session_manager import SessionManager, set_session_manager
@@ -21,6 +23,15 @@ logger = logging.getLogger(__name__)
 
 # Global app instance
 _app: FastAPI | None = None
+
+
+def _request_api_key(request: Request) -> str | None:
+    """Extract an API key from supported HTTP authentication headers."""
+    authorization = request.headers.get("Authorization", "")
+    scheme, _, credential = authorization.partition(" ")
+    if scheme.lower() == "bearer" and credential:
+        return credential
+    return request.headers.get("X-API-Key")
 
 
 @asynccontextmanager
@@ -74,6 +85,7 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
         set_server_config(config)
 
     cfg = get_server_config()
+    cfg.validate_security()
     set_session_manager(SessionManager(cfg))
 
     # Create FastAPI app
@@ -86,6 +98,7 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
         redoc_url="/redoc",
         openapi_url="/openapi.json",
     )
+    app.state.server_config = cfg
 
     # Configure CORS
     if cfg.cors.enabled:
@@ -97,7 +110,40 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
             allow_headers=cfg.cors.allow_headers,
         )
 
+    if cfg.auth.enabled:
+        expected_key = cfg.auth.api_key or ""
+
+        @app.middleware("http")
+        async def require_api_key(request: Request, call_next):
+            """Authenticate all versioned API routes except the health probe."""
+            if request.url.path.startswith("/api/v1/") and request.url.path != "/api/v1/health":
+                supplied_key = _request_api_key(request)
+                if supplied_key is None or not secrets.compare_digest(supplied_key, expected_key):
+                    return JSONResponse(
+                        status_code=401,
+                        content={"error": "Invalid or missing API key", "code": "UNAUTHORIZED"},
+                        headers={"WWW-Authenticate": "Bearer"},
+                    )
+            return await call_next(request)
+
     # Add exception handlers
+    @app.exception_handler(ProviderError)
+    async def provider_exception_handler(request: Request, exc: ProviderError) -> JSONResponse:
+        """Return stable provider diagnostics without leaking SDK exception details."""
+        status_by_kind = {
+            ProviderErrorKind.RATE_LIMIT: 503,
+            ProviderErrorKind.TIMEOUT: 504,
+        }
+        return JSONResponse(
+            status_code=status_by_kind.get(exc.kind, 502),
+            content={
+                "error": str(exc),
+                "code": f"PROVIDER_{exc.kind.value.upper()}",
+                "retryable": exc.retryable,
+                "upstream_status": exc.status_code,
+            },
+        )
+
     @app.exception_handler(Exception)
     async def general_exception_handler(request: Request, exc: Exception) -> JSONResponse:
         """Handle uncaught exceptions."""
@@ -158,6 +204,7 @@ def run_server(
     port: int = 4096,
     work_dir: str | None = None,
     reload: bool = False,
+    auth: AuthConfig | None = None,
 ) -> None:
     """Run the AMCP server.
 
@@ -166,6 +213,7 @@ def run_server(
         port: Port to listen on.
         work_dir: Working directory for sessions.
         reload: Enable auto-reload for development.
+        auth: Authentication config from the application configuration.
     """
     from pathlib import Path
 
@@ -176,7 +224,9 @@ def run_server(
         host=host,
         port=port,
         work_dir=Path(work_dir) if work_dir else None,
+        auth=auth or AuthConfig(),
     )
+    config.validate_security()
     set_server_config(config)
 
     # Create app

--- a/src/amcp/server/config.py
+++ b/src/amcp/server/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 from pathlib import Path
 from typing import Any
 
@@ -31,6 +32,19 @@ class AuthConfig(BaseModel):
     api_key: str | None = None
 
 
+def is_loopback_host(host: str) -> bool:
+    """Return whether a bind host is explicitly local without resolving DNS."""
+    normalized = host.strip().lower().rstrip(".")
+    if normalized == "localhost":
+        return True
+    if normalized.startswith("[") and normalized.endswith("]"):
+        normalized = normalized[1:-1]
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
 class ServerConfig(BaseModel):
     """AMCP Server configuration."""
 
@@ -57,6 +71,13 @@ class ServerConfig(BaseModel):
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return self.model_dump()
+
+    def validate_security(self) -> None:
+        """Reject insecure or incomplete authentication configuration."""
+        if self.auth.enabled and not (self.auth.api_key and self.auth.api_key.strip()):
+            raise ValueError("server authentication is enabled but api_key is empty")
+        if not is_loopback_host(self.host) and not self.auth.enabled:
+            raise ValueError(f"refusing to bind to non-loopback host {self.host!r} without authentication")
 
 
 # Global server config instance

--- a/src/amcp/server/routes/sessions.py
+++ b/src/amcp/server/routes/sessions.py
@@ -11,6 +11,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import StreamingResponse
 
+from ...llm import ProviderError
 from ..interaction import apply_interaction_result, route_server_interaction
 from ..models import (
     CancelRequest,
@@ -359,11 +360,14 @@ async def send_prompt_stream(session_id: str, request: PromptRequest) -> Streami
             )
 
         except Exception as e:
+            provider = e if isinstance(e, ProviderError) else None
             yield (
                 json.dumps(
                     {
                         "type": "error",
                         "error": str(e),
+                        "code": f"PROVIDER_{provider.kind.value.upper()}" if provider else "AGENT_ERROR",
+                        "retryable": provider.retryable if provider else False,
                     }
                 )
                 + "\n"
@@ -434,6 +438,28 @@ async def get_session_history(
             "messages": history,
             "total": len(session.agent.conversation_history),
             "returned": len(history),
+        }
+    except SessionNotFoundError:
+        raise HTTPException(
+            status_code=404,
+            detail={"error": f"Session not found: {session_id}", "code": "SESSION_NOT_FOUND"},
+        ) from None
+
+
+@router.get("/{session_id}/timeline")
+async def get_session_timeline(
+    session_id: str,
+    limit: int = Query(default=100, ge=1, le=1000),
+) -> dict[str, Any]:
+    """Get recent durable, metadata-only execution events for a session."""
+    session_manager = get_session_manager()
+    try:
+        session = await session_manager.get_session(session_id)
+        events = session.agent.get_timeline(limit=limit)
+        return {
+            "session_id": session_id,
+            "events": events,
+            "returned": len(events),
         }
     except SessionNotFoundError:
         raise HTTPException(

--- a/src/amcp/server/session_manager.py
+++ b/src/amcp/server/session_manager.py
@@ -267,6 +267,7 @@ class SessionManager:
 
             session = self._sessions.pop(session_id)
             await session.agent.close()
+            session.agent.delete_persisted_session()
             self._emit_event("session.deleted", {"session_id": session_id})
 
     async def submit_prompt(

--- a/src/amcp/server/websocket.py
+++ b/src/amcp/server/websocket.py
@@ -9,6 +9,7 @@ Provides real-time bidirectional communication for:
 from __future__ import annotations
 
 import asyncio
+import secrets
 import uuid
 from datetime import datetime
 from typing import Any
@@ -173,6 +174,17 @@ async def websocket_endpoint(
         - subscribe: Subscribe to session events
         - ping: Keep-alive ping
     """
+    auth = websocket.scope["app"].state.server_config.auth
+    if auth.enabled:
+        authorization = websocket.headers.get("Authorization", "")
+        scheme, _, bearer_key = authorization.partition(" ")
+        header_key = bearer_key if scheme.lower() == "bearer" and bearer_key else None
+        supplied_key = header_key or websocket.headers.get("X-API-Key")
+        expected_key = auth.api_key or ""
+        if supplied_key is None or not secrets.compare_digest(supplied_key, expected_key):
+            await websocket.close(code=1008, reason="Invalid or missing API key")
+            return
+
     await connection_manager.connect(websocket, session_id)
 
     try:

--- a/src/amcp/session_store.py
+++ b/src/amcp/session_store.py
@@ -8,8 +8,10 @@ import re
 import tempfile
 import threading
 from contextlib import contextmanager, suppress
+from datetime import datetime
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 if os.name == "nt":
     import msvcrt
@@ -28,6 +30,32 @@ _SENSITIVE_KEYS = {
     "password",
     "secret",
     "token",
+}
+_TIMELINE_FIELDS = {
+    "attempt",
+    "cached_input_tokens",
+    "context_tokens",
+    "context_window",
+    "delay_seconds",
+    "duration_ms",
+    "error_kind",
+    "input_tokens",
+    "model",
+    "output_tokens",
+    "partial_output",
+    "priority",
+    "result_length",
+    "settled",
+    "status_code",
+    "step",
+    "success",
+    "task_id",
+    "tool_id",
+    "tool_name",
+    "total_tokens",
+    "turn_id",
+    "turn_status",
+    "usage_from_api",
 }
 
 
@@ -49,6 +77,109 @@ class SessionSaveError(SessionStoreError):
 
 class SessionConflictError(SessionSaveError):
     """Raised when another live owner committed the session first."""
+
+
+def sanitize_timeline_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Keep only non-content metadata approved for durable timeline records."""
+    return {
+        key: value
+        for key, value in data.items()
+        if key in _TIMELINE_FIELDS and isinstance(value, (str, int, float, bool, type(None)))
+    }
+
+
+class SessionTimelineStore:
+    """Bounded append-only JSONL timeline for one session."""
+
+    def __init__(self, root: Path, session_id: str, *, max_events: int = 2000):
+        if max_events < 1:
+            raise ValueError("max_events must be positive")
+        self.root = root.expanduser()
+        self.session_id = validate_session_id(session_id)
+        self.max_events = max_events
+        self.path = self.root / f"{self.session_id}.timeline.jsonl"
+        self.lock_path = self.root / f".{self.session_id}.timeline.lock"
+        self._lock = threading.RLock()
+
+    def append(
+        self,
+        event_type: str,
+        data: dict[str, Any] | None = None,
+        *,
+        timestamp: str | None = None,
+    ) -> dict[str, Any]:
+        """Append one sanitized event and enforce bounded retention."""
+        event = {
+            "id": uuid4().hex,
+            "type": str(event_type),
+            "timestamp": timestamp or datetime.now().isoformat(),
+            "session_id": self.session_id,
+            "data": sanitize_timeline_data(data or {}),
+        }
+        with self._lock:
+            self.root.mkdir(parents=True, exist_ok=True)
+            with self.lock_path.open("a+b") as lock_handle, _exclusive_file_lock(lock_handle):
+                event_count = len(self._read_unlocked())
+                fd = os.open(self.path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+                with os.fdopen(fd, "a", encoding="utf-8") as handle:
+                    handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                event_count += 1
+                if event_count > self.max_events:
+                    retained_count = max(1, int(self.max_events * 0.9))
+                    retained = self._read_unlocked()[-retained_count:]
+                    self._write_unlocked(retained)
+        return event
+
+    def read(self, *, limit: int = 100) -> list[dict[str, Any]]:
+        """Return the newest retained events in chronological order."""
+        if limit < 1:
+            raise ValueError("limit must be positive")
+        with self._lock:
+            if not self.path.exists():
+                return []
+            with self.lock_path.open("a+b") as lock_handle, _exclusive_file_lock(lock_handle):
+                return self._read_unlocked()[-limit:]
+
+    def delete(self) -> None:
+        """Delete this session's durable timeline."""
+        with self._lock:
+            if not self.root.exists():
+                return
+            with self.lock_path.open("a+b") as lock_handle, _exclusive_file_lock(lock_handle):
+                self.path.unlink(missing_ok=True)
+
+    def _read_unlocked(self) -> list[dict[str, Any]]:
+        if not self.path.exists():
+            return []
+        events: list[dict[str, Any]] = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(event, dict):
+                events.append(event)
+        return events
+
+    def _write_unlocked(self, events: list[dict[str, Any]]) -> None:
+        fd, temp_name = tempfile.mkstemp(
+            dir=self.root,
+            prefix=f".{self.session_id}.timeline.",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                for event in events:
+                    handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_name, self.path)
+        except BaseException:
+            with suppress(OSError):
+                os.unlink(temp_name)
+            raise
 
 
 def validate_session_id(session_id: str) -> str:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -13,7 +13,7 @@ from amcp.agent import Agent, AgentExecutionError, BusyError, MaxStepsReached
 from amcp.agent_spec import ResolvedAgentSpec
 from amcp.config import AMCPConfig, ChatConfig, ContextConfig
 from amcp.hooks import HookDecision, HookOutput
-from amcp.llm import LLMResponse, TokenUsage
+from amcp.llm import LLMResponse, ProviderError, ProviderErrorKind, TokenUsage
 from amcp.memory import MemoryManager, MemoryStore
 from amcp.multi_agent import AgentMode
 from amcp.runtime import RuntimeClosedError, TurnStatus
@@ -316,6 +316,101 @@ class TestAgentToolLimits:
         synthesized = llm.seen_messages[1]
         assert synthesized["tool_call_id"] == "missing"
         assert synthesized["name"] == "read_file"
+
+    @pytest.mark.asyncio
+    async def test_retries_transient_provider_failure_and_records_timeline(self, tmp_path):
+        class TransientError(RuntimeError):
+            status_code = 503
+
+        class FakeLLM:
+            def __init__(self):
+                self.calls = 0
+
+            async def achat(self, **_kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    raise TransientError("upstream detail with secret")
+                return SimpleNamespace(content="recovered", tool_calls=None, usage=None)
+
+        with patch("amcp.agent.Path.home", return_value=tmp_path):
+            agent = Agent(session_id="provider-retry")
+
+        llm = FakeLLM()
+        response = await agent._call_llm(
+            llm,
+            messages=[{"role": "user", "content": "hello"}],
+            cfg=ChatConfig(max_retries=1, retry_base_delay_seconds=0),
+        )
+
+        assert response.content == "recovered"
+        assert llm.calls == 2
+        events = agent.get_timeline(limit=10)
+        assert events[-1]["type"] == "provider.retry"
+        assert events[-1]["data"]["error_kind"] == "server"
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_after_streaming_output(self, tmp_path):
+        class FakeLLM:
+            def __init__(self):
+                self.calls = 0
+
+            async def achat(self, stream_callback=None, **_kwargs):
+                self.calls += 1
+                stream_callback("partial")
+                raise TimeoutError("late timeout")
+
+        with patch("amcp.agent.Path.home", return_value=tmp_path):
+            agent = Agent(session_id="provider-stream")
+
+        llm = FakeLLM()
+        with pytest.raises(ProviderError) as error:
+            await agent._call_llm(
+                llm,
+                messages=[{"role": "user", "content": "hello"}],
+                stream_callback=lambda _chunk: None,
+                cfg=ChatConfig(max_retries=3, retry_base_delay_seconds=0),
+            )
+
+        assert error.value.kind == ProviderErrorKind.TIMEOUT
+        assert error.value.partial_output is True
+        assert llm.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_pairing_repair_does_not_retry_after_streaming_output(self, tmp_path):
+        class FakeLLM:
+            def __init__(self):
+                self.calls = 0
+
+            async def achat(self, stream_callback=None, **_kwargs):
+                self.calls += 1
+                stream_callback("partial")
+                error = RuntimeError("INVALID_ARGUMENT: function response parts must equal function call parts")
+                error.status_code = 400
+                raise error
+
+        with patch("amcp.agent.Path.home", return_value=tmp_path):
+            agent = Agent(session_id="pairing-stream")
+
+        llm = FakeLLM()
+        with pytest.raises(ProviderError) as error:
+            await agent._enhanced_chat_with_tools(
+                llm_client=llm,
+                messages=[{"role": "user", "content": "hello"}],
+                tools=[],
+                tool_registry={},
+                stream=True,
+                status=MagicMock(),
+                work_dir=tmp_path,
+                cfg=AMCPConfig(
+                    servers={},
+                    chat=ChatConfig(max_retries=2, retry_base_delay_seconds=0),
+                    context=ContextConfig(),
+                ),
+            )
+
+        assert error.value.partial_output is True
+        assert llm.calls == 1
+        assert agent.current_request_llm_calls == 1
 
     @pytest.mark.asyncio
     async def test_grep_path_is_canonicalized_before_pre_tool_hooks(self, tmp_path):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,6 +10,7 @@ from amcp.client import (
     ClientMode,
     ClientSession,
     HTTPClient,
+    WebSocketClient,
 )
 from amcp.client.base import ResponseChunk
 from amcp.client.embedded import EmbeddedClient
@@ -164,6 +165,57 @@ class TestHTTPClient:
         client = HTTPClient("http://localhost:4096")
         with pytest.raises(ConnectionError):
             client._ensure_connected()
+
+    def test_api_key_adds_bearer_header_without_overriding_headers(self):
+        client = HTTPClient(
+            "http://localhost:4096",
+            headers={"X-Custom": "value"},
+            api_key="secret",
+        )
+        assert client._headers == {
+            "X-Custom": "value",
+            "Authorization": "Bearer secret",
+        }
+
+        custom = HTTPClient(
+            "http://localhost:4096",
+            headers={"authorization": "Custom credential"},
+            api_key="secret",
+        )
+        assert custom._headers["authorization"] == "Custom credential"
+
+
+class TestWebSocketClient:
+    """Test WebSocket authentication and URL construction."""
+
+    def test_api_key_and_session_query(self):
+        client = WebSocketClient(
+            "https://example.test/",
+            session_id="session with spaces",
+            headers={"X-Custom": "value"},
+            api_key="secret",
+        )
+        assert client.ws_url == "wss://example.test/ws?session_id=session+with+spaces"
+        assert client._headers == {
+            "X-Custom": "value",
+            "Authorization": "Bearer secret",
+        }
+
+    @pytest.mark.asyncio
+    async def test_amcp_client_passes_auth_to_http_client(self, monkeypatch):
+        async def connect_without_network(client):
+            client._client = object()
+
+        monkeypatch.setattr(HTTPClient, "connect", connect_without_network)
+        client = AMCPClient.remote(
+            "https://example.test",
+            headers={"X-Custom": "value"},
+            api_key="secret",
+        )
+        await client.connect()
+        assert isinstance(client._client, HTTPClient)
+        assert client._client._headers["Authorization"] == "Bearer secret"
+        assert client._client._headers["X-Custom"] == "value"
 
 
 # ============================================================================

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,6 +58,36 @@ def test_decode_encode_chat_tool_limits_roundtrip():
     assert encoded["bash_tool_limit"] == 100
 
 
+def test_decode_encode_provider_reliability_policy_roundtrip():
+    raw = {
+        "request_timeout_seconds": 45.5,
+        "max_retries": 4,
+        "retry_base_delay_seconds": 0.25,
+        "active_provider": "backup",
+        "providers": {
+            "backup": {
+                "api_type": "anthropic",
+                "model": "backup-model",
+                "request_timeout_seconds": 30,
+                "max_retries": 1,
+                "retry_base_delay_seconds": 0.1,
+            }
+        },
+    }
+
+    cfg = config_module._decode_chat(raw)
+
+    assert cfg is not None
+    assert cfg.request_timeout_seconds == 30
+    assert cfg.max_retries == 1
+    assert cfg.retry_base_delay_seconds == 0.1
+    encoded = config_module._encode_chat(cfg)
+    assert encoded is not None
+    assert encoded["providers"]["backup"]["request_timeout_seconds"] == 30.0
+    assert encoded["providers"]["backup"]["max_retries"] == 1
+    assert encoded["providers"]["backup"]["retry_base_delay_seconds"] == 0.1
+
+
 def test_default_chat_uses_gmi_without_api_key():
     cfg = config_module._decode_chat(config_module._DEFAULT["chat"])
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import httpx
 import pytest
 from any_llm.types.completion import Reasoning
 
@@ -13,6 +14,8 @@ from amcp.llm import (
     LLMResponse,
     OpenAIClient,
     OpenAIResponsesClient,
+    ProviderErrorKind,
+    classify_provider_error,
     create_llm_client,
 )
 
@@ -31,6 +34,52 @@ class TestLLMResponse:
         assert resp.tool_calls == tool_calls
 
 
+class TestProviderErrors:
+    """Tests for safe provider exception classification."""
+
+    @pytest.mark.parametrize(
+        ("status", "kind", "retryable"),
+        [
+            (401, ProviderErrorKind.AUTH, False),
+            (400, ProviderErrorKind.INVALID_REQUEST, False),
+            (429, ProviderErrorKind.RATE_LIMIT, True),
+            (503, ProviderErrorKind.SERVER, True),
+        ],
+    )
+    def test_classifies_http_statuses(self, status, kind, retryable):
+        error = RuntimeError("secret provider response")
+        error.status_code = status
+
+        classified = classify_provider_error(error)
+
+        assert classified.kind == kind
+        assert classified.retryable is retryable
+        assert "secret provider response" not in str(classified)
+
+    def test_partial_stream_output_disables_retry(self):
+        error = classify_provider_error(TimeoutError(), partial_output=True)
+
+        assert error.kind == ProviderErrorKind.TIMEOUT
+        assert error.retryable is False
+        assert error.partial_output is True
+
+    @pytest.mark.parametrize(
+        ("wrapped", "kind"),
+        [
+            (httpx.ReadError("connection reset"), ProviderErrorKind.CONNECTION),
+            (httpx.ReadTimeout("slow provider"), ProviderErrorKind.TIMEOUT),
+        ],
+    )
+    def test_classifies_httpx_transport_errors(self, wrapped, kind):
+        outer = RuntimeError("provider wrapper")
+        outer.original_exception = wrapped
+
+        classified = classify_provider_error(outer)
+
+        assert classified.kind == kind
+        assert classified.retryable is True
+
+
 class TestCreateLLMClient:
     """Tests for create_llm_client factory."""
 
@@ -43,6 +92,15 @@ class TestCreateLLMClient:
         cfg = ChatConfig(api_type="openai", model="gpt-5.5", api_key="test-key")
         client = create_llm_client(cfg)
         assert isinstance(client, OpenAIClient)
+
+    @pytest.mark.parametrize("api_type", ["openai", "anthropic", "gmi"])
+    def test_known_providers_disable_sdk_retries(self, api_type):
+        cfg = ChatConfig(api_type=api_type, model="test-model", api_key="test-key")
+
+        with patch("any_llm.AnyLLM.create") as create:
+            create_llm_client(cfg)
+
+        assert create.call_args.kwargs["max_retries"] == 0
 
     def test_openai_responses_type(self):
         cfg = ChatConfig(api_type="openai_responses", model="gpt-5.5", api_key="test-key")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,8 +6,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from amcp.server import ServerConfig, create_app
+from amcp.server.config import AuthConfig, is_loopback_host
 from amcp.server.models import SessionStatus
 from amcp.server.session_manager import (
     ManagedSession,
@@ -17,6 +19,7 @@ from amcp.server.session_manager import (
     SessionNotFoundError,
     get_session_manager,
 )
+from amcp.session_store import SessionTimelineStore
 
 
 @pytest.fixture
@@ -78,6 +81,87 @@ class TestHealthEndpoints:
         assert "sessions" in data["capabilities"]
 
 
+class TestServerAuthentication:
+    """Test unified HTTP and WebSocket API-key authentication."""
+
+    @pytest.fixture
+    def authenticated_client(self):
+        config = ServerConfig(auth=AuthConfig(enabled=True, api_key="test-secret"))
+        return TestClient(create_app(config))
+
+    @pytest.mark.parametrize(
+        "headers",
+        [{}, {"Authorization": "Bearer wrong"}, {"X-API-Key": "wrong"}],
+    )
+    def test_http_rejects_missing_or_wrong_key(self, authenticated_client, headers):
+        response = authenticated_client.get("/api/v1/info", headers=headers)
+        assert response.status_code == 401
+
+    @pytest.mark.parametrize(
+        "headers",
+        [
+            {"Authorization": "Bearer test-secret"},
+            {"X-API-Key": "test-secret"},
+        ],
+    )
+    def test_http_accepts_supported_key_headers(self, authenticated_client, headers):
+        response = authenticated_client.get("/api/v1/info", headers=headers)
+        assert response.status_code == 200
+
+    def test_health_and_root_are_public(self, authenticated_client):
+        assert authenticated_client.get("/api/v1/health").status_code == 200
+        assert authenticated_client.get("/").status_code == 200
+
+    @pytest.mark.parametrize(
+        ("url", "headers"),
+        [
+            ("/ws?api_key=test-secret", {}),
+            ("/ws?api_key=wrong", {}),
+            ("/ws", {"Authorization": "Bearer wrong"}),
+        ],
+    )
+    def test_websocket_rejects_missing_or_wrong_key(self, authenticated_client, url, headers):
+        with pytest.raises(WebSocketDisconnect), authenticated_client.websocket_connect(url, headers=headers):
+            pass
+
+    @pytest.mark.parametrize(
+        ("url", "headers"),
+        [
+            ("/ws", {"Authorization": "Bearer test-secret"}),
+            ("/ws", {"X-API-Key": "test-secret"}),
+        ],
+    )
+    def test_websocket_accepts_supported_headers(self, authenticated_client, url, headers):
+        with authenticated_client.websocket_connect(url, headers=headers) as websocket:
+            message = websocket.receive_json()
+            assert message["payload"]["kind"] == "connected"
+
+    def test_websocket_auth_is_scoped_to_its_app(self):
+        authenticated_app = create_app(ServerConfig(auth=AuthConfig(enabled=True, api_key="app-secret")))
+        create_app(ServerConfig())
+
+        with (
+            TestClient(authenticated_app) as client,
+            pytest.raises(WebSocketDisconnect),
+            client.websocket_connect("/ws"),
+        ):
+            pass
+
+    @pytest.mark.parametrize("host", ["0.0.0.0", "::", "example.internal"])
+    def test_non_loopback_without_auth_is_rejected(self, host):
+        with pytest.raises(ValueError, match="non-loopback"):
+            create_app(ServerConfig(host=host))
+
+    @pytest.mark.parametrize("host", ["localhost", "localhost.", "127.0.0.1", "::1"])
+    def test_loopback_hosts_are_recognized(self, host):
+        assert is_loopback_host(host)
+
+    @pytest.mark.parametrize("api_key", [None, "", "   "])
+    def test_enabled_auth_requires_nonempty_key(self, api_key):
+        with pytest.raises(ValueError, match="api_key is empty"):
+            create_app(ServerConfig(auth=AuthConfig(enabled=True, api_key=api_key)))
+
+
 class TestSessionEndpoints:
     """Test session management endpoints."""
 
@@ -119,11 +203,40 @@ class TestSessionEndpoints:
         response = client.get("/api/v1/sessions/nonexistent-id")
         assert response.status_code == 404
 
+    def test_get_durable_sanitized_timeline(self, client, tmp_path):
+        create_resp = client.post("/api/v1/sessions", json={"cwd": "/tmp"})
+        session_id = create_resp.json()["id"]
+        managed = asyncio.run(get_session_manager().get_session(session_id))
+        managed.agent._timeline_store = SessionTimelineStore(tmp_path, session_id)
+        managed.agent._emit_event(
+            "tool.call_start",
+            {
+                "tool_name": "bash",
+                "tool_id": "call-1",
+                "arguments": {"command": "echo secret"},
+            },
+        )
+
+        response = client.get(f"/api/v1/sessions/{session_id}/timeline")
+
+        assert response.status_code == 200
+        events = response.json()["events"]
+        assert events[-1]["type"] == "tool.call_start"
+        assert events[-1]["data"] == {"tool_name": "bash", "tool_id": "call-1"}
+        assert "secret" not in managed.agent._timeline_store.path.read_text(encoding="utf-8")
+
     def test_delete_session(self, client):
         """Test deleting a session."""
         # Create a session
         create_resp = client.post("/api/v1/sessions", json={"cwd": "/tmp"})
         session_id = create_resp.json()["id"]
+        managed = asyncio.run(get_session_manager().get_session(session_id))
+        managed.agent._emit_event("turn.completed", {"turn_id": "turn-delete"})
+        timeline_path = managed.agent._timeline_store.path
+        managed.agent._save_conversation_history()
+        snapshot_path = managed.agent.session_file
+        assert timeline_path.exists()
+        assert snapshot_path.exists()
 
         # Delete the session
         response = client.delete(f"/api/v1/sessions/{session_id}")
@@ -132,6 +245,8 @@ class TestSessionEndpoints:
         # Verify it's deleted
         get_resp = client.get(f"/api/v1/sessions/{session_id}")
         assert get_resp.status_code == 404
+        assert not timeline_path.exists()
+        assert not snapshot_path.exists()
 
     def test_prompt_stream_new_session_command(self, client):
         """Test /new through the server prompt stream creates a session."""

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -13,6 +13,7 @@ from amcp.session_store import (
     SessionLoadError,
     SessionSaveError,
     SessionStore,
+    SessionTimelineStore,
 )
 
 
@@ -43,6 +44,44 @@ def test_save_is_versioned_atomic_and_redacts_sensitive_fields(tmp_path):
     assert data["tool"]["api_key"] == "[REDACTED]"
     assert data["tool"]["headers"]["Authorization"] == "[REDACTED]"
     assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_timeline_is_sanitized_bounded_and_restartable(tmp_path):
+    store = SessionTimelineStore(tmp_path, "timeline", max_events=3)
+    store.append(
+        "tool.call_start",
+        {
+            "tool_name": "bash",
+            "tool_id": "call-1",
+            "arguments": {"command": "echo secret"},
+            "error": "Bearer secret",
+        },
+    )
+    store.append("tool.call_complete", {"tool_name": "bash", "success": True})
+    store.append("llm.usage", {"input_tokens": 10, "output_tokens": 2})
+    store.append("turn.completed", {"turn_id": "turn-1", "turn_status": "completed"})
+
+    restarted = SessionTimelineStore(tmp_path, "timeline", max_events=3)
+    events = restarted.read(limit=10)
+
+    assert [event["type"] for event in events] == ["llm.usage", "turn.completed"]
+    assert events[0]["data"] == {"input_tokens": 10, "output_tokens": 2}
+    raw = restarted.path.read_text(encoding="utf-8")
+    assert "echo secret" not in raw
+    assert "Bearer secret" not in raw
+
+
+def test_timeline_retention_is_shared_across_writers(tmp_path):
+    first = SessionTimelineStore(tmp_path, "shared-timeline", max_events=3)
+    second = SessionTimelineStore(tmp_path, "shared-timeline", max_events=3)
+
+    for index in range(8):
+        writer = first if index % 2 == 0 else second
+        writer.append("turn.completed", {"turn_id": f"turn-{index}"})
+
+    events = first.read(limit=10)
+    assert len(events) <= 3
+    assert events[-1]["data"]["turn_id"] == "turn-7"
 
 
 def test_atomic_replace_failure_preserves_previous_session(tmp_path):


### PR DESCRIPTION
# Pull Request

## Description

Harden AMCP's remote runtime and improve its reliability and onboarding:

- require API-key authentication for protected HTTP and WebSocket endpoints, and reject unauthenticated non-loopback binds
- propagate authentication through the HTTP, WebSocket, unified clients, and `amcp attach`
- classify provider failures and add bounded timeout/retry behavior for transient foreground tool-loop model calls
- persist a bounded, metadata-only execution timeline for turns, tools, tasks, provider retries, compaction, and token usage
- refresh the README, Quick Start, historical Telegram guidance, examples, package names, and repository-local links

Timeline persistence deliberately excludes prompts, tool arguments, tool output, and raw provider exception text.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Testing

```bash
python -m pytest -q -m "not llm"
ruff format --check src tests
ruff check src tests
mypy src/amcp/agent.py src/amcp/cli.py src/amcp/client src/amcp/config.py src/amcp/event_bus.py src/amcp/llm.py src/amcp/server src/amcp/session_store.py --ignore-missing-imports
python -m compileall -q src/amcp
```

Results:

- 893 non-LLM tests passed
- Ruff formatting and lint checks passed
- Mypy passed for all files changed in this PR
- all repository-local Markdown links resolve

The repository-wide mypy command still reports four pre-existing `Future`/`Task` errors in `src/amcp/tools.py` that are unrelated to this PR.

## Related Issues

None.
