### PR TITLE
docs: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,210 @@
+# Changelog
+
+All notable changes to AMCP are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **Provider error classification and retry** (`#28`): structured `ProviderError` with type, retryability, and `retry_after`; agent-level exponential backoff with jitter for transient errors; partial-stream detection disables retry to prevent duplicate messages.
+- **Persistent session timeline** (`#28`): `SessionTimelineStore` appends sanitized JSONL events per session with bounded retention (2000 events, 90% kept). All secrets and content fields are stripped via whitelist before persistence.
+- **Server authentication** (`#28`): `validate_security()` refuses to start when auth is enabled without a key, or bound to a non-loopback address without auth. HTTP middleware uses constant-time comparison (`secrets.compare_digest`). WebSocket endpoints enforce auth on upgrade.
+- **MCP tool-call pairing repair** (`#27`): traverses full exception chain (not just outermost) for `_is_tool_call_pairing_error`; MCP tools exposed under provider-safe function names.
+
+### Fixed
+
+- **Sub-agent task lifecycle** (`#28`): hardened ownership tracking and cancellation propagation for spawned sub-agents.
+- **Agent runtime ownership and cancellation** (`#28`): deterministic turn cancellation with `TurnHandle`; `RuntimeClosedError` and `TurnCancelledError` for clean teardown.
+- **Duplicate Telegram memory history** (`#28`): memory log entries no longer duplicated when Telegram delivery retries.
+- **Gemini tool-call pairing** (`#27`): `_repair_tool_call_pairing` now synthesizes missing tool responses and drops orphaned results, preserving Gemini thought signatures.
+- **Grep singular path** (`#26`): `grep` tool accepts a single `path` string (previously required a list).
+
+---
+
+## [0.12.0] — 2026-07-19
+
+### Added
+
+- **any-llm provider migration** (`#23`): LLM backend migrated from hand-rolled OpenAI client to [`any-llm-sdk`](https://pypi.org/project/any-llm-sdk/), adding first-class support for Anthropic Claude, Google Gemini, and any OpenAI-compatible endpoint. Provider selection is config-driven via `[chat.providers.<name>]`.
+- **Telegram scheduled prompt loop**: in-process cron scheduler for recurring autonomous tasks, triggered by natural language or blueprint-based prompts. Store-backed persistence survives restarts.
+- **Telegram memory dream loop**: `MemoryDreamer` periodically consolidates recent episodic events into long-term `MEMORY.md` using an LLM pass, discarding transient chatter and keeping durable facts.
+- **Session transcript indexing**: `session_search` tool searches persisted conversation history across all sessions via SQLite FTS5.
+- **Structured compaction summaries**: context compaction now produces structured summaries instead of flat text, improving follow-up turn quality.
+- **Periodic memory review isolation**: memory review runs on a turn interval (`MEMORY_REVIEW_TURN_INTERVAL = 10`) without blocking the main tool loop.
+- **Telegram session reset serialization**: `/new` and session abandonment are serialized to prevent race conditions between concurrent turns.
+- **Frozen memory prompt context**: memory guidance text is frozen per-turn to avoid mid-turn drift.
+
+### Changed
+
+- **V2-only session schema** (`#24`): legacy V1 session files are no longer loaded; `SessionState` is now the canonical, recoverable representation. Session runtime unified with real cancellation and async execution.
+- **Tool capabilities and workspace confinement** (`#24`): tools declare capabilities (read/write/execute); workspace boundaries enforced for file operations; session persistence hardened against partial writes.
+- **Default model updated to GPT-5.5**: legacy `gpt-4o` references replaced throughout config defaults and model metadata.
+- **Server and Telegram session queues aligned** (`#22`): both transports now use the same bounded-queue logic with consistent backpressure behavior.
+- **Telegram `/schedule` command hidden** in favor of natural-language scheduling.
+- **Built-in web providers hidden** from the model picker; users configure their own via `config.toml`.
+- **Legacy REPL chat path removed**: `repl` read shortcut and legacy chat module cleaned up.
+
+### Fixed
+
+- **All mypy type errors resolved** (72 → 0): full type coverage across `src/amcp`.
+- **Configured LLM base URLs preserved**: provider-specific `base_url` no longer overwritten by defaults.
+- **Telegram typing indicator**: now stops correctly after response delivery (previously could persist).
+- **CI compatibility with latest Ruff**: formatting and lint rules updated.
+
+### Removed
+
+- **ACP (Agent Client Protocol) integration** removed: AMCP no longer ships ACP server/client code. The HTTP/WebSocket API remains the primary remote interface.
+
+---
+
+## [0.11.1] — 2026-07-19
+
+### Fixed
+
+- Patch release with no user-facing changes; version bump to align PyPI publication.
+
+---
+
+## [0.11.0] — 2026-07-06
+
+### Added
+
+- **Telegram memory persistence** (`#21`): memories created in Telegram sessions are now flushed to persistent storage across sessions, not lost on restart.
+- **Context usage in Telegram status** (`#20`): the Telegram status line now shows current context window utilization, giving visibility into compaction triggers.
+- **Docker image published to GHCR** (`#18`): CI workflow builds and pushes the AMCP image to `ghcr.io/tao12345666333/amcp` on every tag and main push.
+- **Telegram provider switching** (`#17`): `/model` command switches active LLM provider at runtime without restart.
+- **Telegram sender photo support**: the `telegram-sender` skill and `telegram_send` tool can now send images.
+
+### Fixed
+
+- **Reasoning-only provider replies surfaced**: responses containing only reasoning content (no text body) are no longer silently dropped.
+- **Context overflow guard**: LLM requests are checked against the model's context window before sending, preventing provider-side truncation errors.
+- **Telegram Markdown rendering** (`#19`): Markdown responses now render correctly in Telegram using `telegramify-markdown`.
+- **AMCP user agent on OpenAI clients**: custom `User-Agent` header set on all outbound LLM requests.
+
+### Changed
+
+- **Default provider switched to GMI Cloud** (`#4c1785b`): `gmi` with `openai/gpt-5.5` is the new out-of-box default.
+- **Cron CLI commands removed**: scheduling is now handled by the Telegram scheduler and `config.toml` automation jobs.
+
+---
+
+## [0.10.1] — 2026-07-05
+
+### Fixed
+
+- **Bash tool limit raised** (`#13`): default `bash_tool_limit` increased to support longer autonomous tasks without manual override.
+- **Project positioning refresh** (`#12`): README and docs updated to reflect the "runtime, not framework" positioning.
+
+---
+
+## [0.10.0] — 2026-01-19
+
+### Added
+
+- **Soul, identity, and persistent memory** with pre-compaction flush: `SOUL.md` and `IDENTITY.md` define the agent's durable persona; memory is flushed before context compaction to prevent loss.
+- **SQLite + FTS5 persistent memory**: episodic events and declarative facts stored in `memory.db` with full-text search.
+- **Telegram bot integration** (`#6`): full Telegram support with DM/group policies, pairing via one-time codes, topic/thread support, rate limiting, typing indicators, and bounded per-session queues.
+- **In-process assistant scheduler**: cron-based autonomous task execution in Telegram mode, with blueprint-based and custom scheduled prompts.
+- **First-class `TelegramSendTool`**: agent can send messages and photos directly via Telegram Bot API.
+- **Web search and fetch tools**: built-in `web_search` and `web_fetch` work without external API keys.
+- **Networked research skill**: multi-source web research with synthesis.
+- **Skills system** (`#2`, `#3`): reusable skill definitions (Markdown + YAML frontmatter) with auto-triggers, parameters, hot reload, and `/skill:` command. Built-in `skill-creator` for self-evolution.
+- **Slash commands**: TOML-based custom commands with `{{args}}`, `!{shell}`, and `@{file}` interpolation.
+- **Heartbeat builtin skill**: file-driven periodic health checks and proactive task execution.
+- **Multimedia message support** for Telegram: photos, audio, documents parsed and forwarded to the agent.
+- **Unified interaction routing**: slash commands share a single routing layer across CLI, server, and Telegram.
+- **Progressive context view (Phase 9 MVP)**: tools and skills loaded dynamically based on relevance scoring and context budget.
+
+### Changed
+
+- **Bash tool promoted to always tier**: available from the first turn without progressive loading.
+- **Project documentation refreshed**: README, contributing guide, and project structure docs updated.
+- **License unified to Apache-2.0**.
+
+### Fixed
+
+- **Telegram session isolation after failures**: failed sessions are quarantined rather than blocking the chat.
+- **Model config propagation**: `model_config` now correctly flows to context window resolution; default raised to 200K.
+- **Thread safety for `TodoTool` and global tool registry**.
+
+### Removed
+
+- **Daemon process management**: removed in favor of Docker/systemd for production deployments.
+- **Toad TUI support**: removed to reduce surface area.
+- **Legacy `jobs` system**: replaced by `config.toml` automation and the Telegram scheduler.
+
+---
+
+## [0.9.0] — 2026-01-07
+
+### Added
+
+- **Client-Server architecture (Phase 2-3)**: FastAPI HTTP/WebSocket server with streaming, SSE events, session management, and a Python client SDK (`embedded`, `http_client`, `ws_client` transports).
+- **Live rendering**: streaming responses rendered incrementally in the CLI.
+
+---
+
+## [0.8.0] — 2026-01-05
+
+### Added
+
+- **Toad TUI option** (`#1`): optional terminal UI mode.
+
+### Fixed
+
+- **72 mypy type checking errors resolved**.
+
+---
+
+## [0.7.0] — 2026-01-02
+
+### Added
+
+- **Indentation-aware file reading mode**: `read_file` supports anchor-based context expansion around functions and classes.
+- **Installation instructions** improved in README.
+
+### Fixed
+
+- **`readfile` indexing bug**.
+
+---
+
+## [0.6.0] — 2025-12-29
+
+### Added
+
+- **Skills and commands system**: extensible agent capabilities via skill definitions and slash commands.
+- **`apply_patch` tool**: diff-based patching for efficient multi-line edits.
+
+---
+
+## [0.5.0] — 2025-12-27
+
+### Added
+
+- **Hooks system**: configurable `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `SessionStart`, `SessionEnd`, `Stop`, and `PreCompact` hooks via TOML or JSON.
+
+---
+
+## [0.4.0] — 2025-11-30
+
+### Added
+
+- Initial public release: core agent engine, built-in tools (`read_file`, `grep`, `bash`, `write_file`), TOML configuration, CLI interface, and Dockerfile.
+
+[Unreleased]: https://github.com/tao12345666333/amcp/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/tao12345666333/amcp/compare/v0.11.1...v0.12.0
+[0.11.1]: https://github.com/tao12345666333/amcp/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/tao12345666333/amcp/compare/v0.10.1...v0.11.0
+[0.10.1]: https://github.com/tao12345666333/amcp/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/tao12345666333/amcp/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/tao12345666333/amcp/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/tao12345666333/amcp/compare/v0.7.3...v0.8.0
+[0.7.0]: https://github.com/tao12345666333/amcp/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/tao12345666333/amcp/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/tao12345666333/amcp/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/tao12345666333/amcp/releases/tag/v0.4.0


### PR DESCRIPTION
## Summary

Adds a `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/) format, covering all releases from v0.4.0 through v0.12.0 plus an Unreleased section for post-v0.12.0 work.

- **v0.11.0, v0.11.1, v0.12.0, and Unreleased**: detailed entries with Added/Changed/Fixed/Removed sections and PR references.
- **v0.4.0–v0.10.0**: concise per-version summaries of the major changes.

All release dates and compare links are generated from git tags.

## Testing

- Docs-only change; no code or tests affected.
- Pre-commit hooks pass (trailing whitespace, end-of-file, large file check).