### PR TITLE
fix: remove insecure direct tool execution HTTP endpoint

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,7 +1,7 @@
 # AMCP API Reference
 
-> **Version**: 1.0.0  
-> **Base URL**: `http://localhost:4096/api/v1`  
+> **Version**: 1.0.0
+> **Base URL**: `http://localhost:4096/api/v1`
 > **OpenAPI Spec**: `/openapi.json`
 
 This document provides comprehensive API documentation for the AMCP Server HTTP REST API, WebSocket API, and SSE event streams.
@@ -277,33 +277,6 @@ List all available tools.
     }
   ],
   "total": 15
-}
-```
-
-#### POST `/tools/{name}/execute`
-
-Execute a tool directly (bypassing the agent).
-
-**Path Parameters**:
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `name` | string | Tool name |
-
-**Request Body**:
-```json
-{
-  "arguments": {
-    "path": "/src/main.py"
-  }
-}
-```
-
-**Response** `200 OK`:
-```json
-{
-  "success": true,
-  "result": "file contents...",
-  "error": null
 }
 ```
 
@@ -601,11 +574,11 @@ from amcp.client import AMCPClient
 async with AMCPClient("http://localhost:4096") as client:
     # Create session
     session = await client.create_session(cwd="/my/project")
-    
+
     # Stream response
     async for chunk in await session.prompt_stream("Help me refactor"):
         print(chunk.content, end="")
-    
+
     # Full response
     response = await session.prompt_full("What did you do?")
 ```

--- a/src/amcp/server/routes/tools.py
+++ b/src/amcp/server/routes/tools.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from fastapi import APIRouter, HTTPException
 
 from ..models import ToolInfo, ToolListResponse
@@ -74,51 +72,6 @@ async def get_tool(tool_name: str) -> ToolInfo:
         parameters={},
         source="builtin",
     )
-
-
-@router.post("/{tool_name}/execute")
-async def execute_tool(tool_name: str, arguments: dict[str, Any]) -> dict:
-    """Execute a tool directly.
-
-    This is mainly for testing purposes. In normal operation,
-    tools are executed as part of agent conversations.
-
-    Warning: This bypasses normal safety checks.
-    """
-    from ...tools import ToolResult, get_tool_registry
-
-    tool_registry = get_tool_registry()
-    tool_func = tool_registry.get_tool(tool_name)
-
-    if tool_func is None:
-        raise HTTPException(
-            status_code=404,
-            detail={"error": f"Tool not found: {tool_name}", "code": "TOOL_NOT_FOUND"},
-        )
-
-    try:
-        arguments = tool_registry.prepare_model_arguments(tool_name, arguments)
-        result = tool_registry.execute_tool(tool_name, **arguments)
-
-        if isinstance(result, ToolResult):
-            return {
-                "success": result.success,
-                "result": result.content,
-                "error": result.error,
-            }
-        else:
-            return {
-                "success": True,
-                "result": str(result),
-                "error": None,
-            }
-
-    except Exception as e:
-        return {
-            "success": False,
-            "result": None,
-            "error": str(e),
-        }
 
 
 @router.get("/categories")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -350,6 +350,11 @@ class TestToolEndpoints:
         response = client.get("/api/v1/tools/nonexistent_tool")
         assert response.status_code == 404
 
+    def test_execute_tool_endpoint_removed(self, client):
+        """Test that the direct execute endpoint is no longer available."""
+        response = client.post("/api/v1/tools/read_file/execute", json={"arguments": {}})
+        assert response.status_code == 404
+
 
 class TestAgentEndpoints:
     """Test agent management endpoints."""


### PR DESCRIPTION
## Summary

Removes the `POST /tools/{tool_name}/execute` HTTP route that bypassed all safety checks.

### Problem

The endpoint called `ToolRegistry.execute_tool()` directly, skipping:
- Session/workspace binding
- Capability and allowed-tools validation
- Tool hooks (PreToolUse/PostToolUse)
- Timeline semantics
- `ToolExecutor` path boundaries
- Normal cancellation mechanism

Even with API key authentication, this endpoint was an unguarded path to arbitrary tool execution.

### Changes

- **Removed** `execute_tool` route from `src/amcp/server/routes/tools.py`
- **Removed** corresponding section from `docs/api/README.md`
- **Added** test verifying the endpoint returns 404
- Tool listing (`GET /tools`) and detail (`GET /tools/{name}`) endpoints remain unchanged
- Agent-internal tool execution via `ToolExecutor` is completely unaffected

### Verification

- `POST /api/v1/tools/read_file/execute` → 404
- `GET /api/v1/tools` → 200 (list still works)
- `GET /api/v1/tools/read_file` → 200 (detail still works)
- All 65 server tests pass