### PR TITLE
feat: add Telegram streaming output for LLM responses

### DIFF
--- a/src/amcp/config.py
+++ b/src/amcp/config.py
@@ -20,6 +20,7 @@ from .telegram.config import (
     TelegramGroupConfig,
     TelegramNotificationsConfig,
     TelegramPairingConfig,
+    TelegramStreamingConfig,
     TelegramTopicConfig,
     apply_env_overrides,
     normalize_dm_policy,
@@ -561,6 +562,21 @@ def _decode_telegram_pairing(raw: Mapping[str, object] | None) -> TelegramPairin
     )
 
 
+def _decode_telegram_streaming(raw: Mapping[str, object] | None) -> TelegramStreamingConfig:
+    cfg = TelegramStreamingConfig()
+    if not raw:
+        return cfg
+    if "streaming_enabled" in raw:
+        cfg.streaming_enabled = bool(raw.get("streaming_enabled"))
+    if "streaming_interval_seconds" in raw and raw.get("streaming_interval_seconds") is not None:
+        cfg.streaming_interval_seconds = max(0.3, float(str(raw.get("streaming_interval_seconds"))))
+    if "streaming_min_chars" in raw and raw.get("streaming_min_chars") is not None:
+        cfg.streaming_min_chars = max(1, int(str(raw.get("streaming_min_chars"))))
+    if "streaming_max_chars" in raw and raw.get("streaming_max_chars") is not None:
+        cfg.streaming_max_chars = max(100, int(str(raw.get("streaming_max_chars"))))
+    return cfg
+
+
 def _decode_telegram_topic(raw: Mapping[str, object] | None) -> TelegramTopicConfig:
     if not raw:
         return TelegramTopicConfig()
@@ -630,6 +646,9 @@ def _decode_telegram(raw: Mapping[str, object] | None) -> TelegramConfig | None:
 
     pairing = raw.get("pairing")
     cfg.pairing = _decode_telegram_pairing(pairing if isinstance(pairing, dict) else None)
+
+    streaming = raw.get("streaming")
+    cfg.streaming = _decode_telegram_streaming(streaming if isinstance(streaming, dict) else None)
 
     groups: dict[str, TelegramGroupConfig] = {}
     raw_groups = raw.get("groups")

--- a/src/amcp/telegram/bot.py
+++ b/src/amcp/telegram/bot.py
@@ -6,6 +6,7 @@ import logging
 import os
 import secrets
 import string
+import time
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta
@@ -19,9 +20,9 @@ from ..event_bus import EventType, get_event_bus
 from ..memory import CONFIG_DIR
 from ..memory_dream import MemoryDreamer
 from ..multi_agent import get_agent_registry
-from ..runtime import CancellationResult, TurnStatus
+from ..runtime import CancellationResult, TurnCancelledError, TurnStatus
 from .auth import AuthMiddleware
-from .config import TelegramConfig, normalize_dm_policy, normalize_group_policy
+from .config import TelegramConfig, TelegramStreamingConfig, normalize_dm_policy, normalize_group_policy
 from .formatter import TelegramFormatter
 from .handlers import (
     RateLimiter,
@@ -60,6 +61,112 @@ class PairingRequest:
     chat_id: int
     username: str | None
     created_at: datetime
+
+
+class _StreamingDeliveryManager:
+    """Accumulate LLM chunks and periodically edit a Telegram status message.
+
+    The manager throttles ``edit_message_text`` calls to respect Telegram
+    rate limits (roughly 30 per minute per chat).  When the accumulated text
+    exceeds ``max_chars``, the current message is sealed (final edit) and a
+    new message is started for overflow content.
+    """
+
+    def __init__(
+        self,
+        bot: Any,
+        chat_id: int,
+        status_message_id: int | None,
+        formatter: TelegramFormatter,
+        cfg: TelegramStreamingConfig,
+        is_current: Callable[[], bool],
+        stop_markup: Any = None,
+    ) -> None:
+        self._bot = bot
+        self._chat_id = chat_id
+        self._message_id = status_message_id
+        self._formatter = formatter
+        self._cfg = cfg
+        self._is_current = is_current
+        self._stop_markup = stop_markup
+        self._buffer: str = ""
+        self._last_edit_time: float = 0.0
+        self._sealed_messages: list[str] = []
+        self._overflow_message_id: int | None = None
+        self._needs_flush: bool = False
+
+    def on_chunk(self, event_type: str, data: dict[str, Any]) -> None:
+        """Synchronous callback invoked by the agent event system.
+
+        Only accumulates text; the actual Telegram edit is deferred to
+        ``maybe_flush`` which runs in the async context of _process_message.
+        """
+        if event_type != "message.chunk":
+            return
+        chunk = data.get("content", "")
+        if not chunk:
+            return
+        self._buffer += chunk
+        now = time.monotonic()
+        if len(self._buffer) >= self._cfg.streaming_min_chars and (
+            now - self._last_edit_time >= self._cfg.streaming_interval_seconds
+        ):
+            self._needs_flush = True
+
+    async def maybe_flush(self) -> None:
+        """Edit the status message if enough content has accumulated.
+
+        Called periodically from the async context in ``_process_message``.
+        """
+        if not self._needs_flush or not self._buffer:
+            return
+        self._needs_flush = False
+        if not self._is_current():
+            return
+        self._last_edit_time = time.monotonic()
+        if len(self._buffer) > self._cfg.streaming_max_chars:
+            seal_text = self._buffer[: self._cfg.streaming_max_chars]
+            self._buffer = self._buffer[self._cfg.streaming_max_chars :]
+            await self._seal_and_send(seal_text)
+        else:
+            await self._edit_status(self._buffer)
+
+    async def _seal_and_send(self, sealed_text: str) -> None:
+        """Seal current message with sealed_text, start new message for buffer."""
+        await self._edit_status(sealed_text)
+        self._sealed_messages.append(sealed_text)
+        try:
+            msg = await self._bot.send_text(self._chat_id, self._buffer[: self._cfg.streaming_max_chars])
+            self._overflow_message_id = self._bot._get_telegram_message_id(msg)
+        except Exception:
+            logger.debug("Failed to send overflow streaming message", exc_info=True)
+
+    async def _edit_status(self, text: str) -> None:
+        if self._message_id is None:
+            return
+        try:
+            await self._bot._edit_text(self._chat_id, self._message_id, text, markdown=False)
+        except Exception:
+            logger.debug("Streaming edit failed for %s/%s", self._chat_id, self._message_id, exc_info=True)
+
+    async def finalize(self, full_response: str) -> None:
+        """Deliver the final formatted response with proper markdown."""
+        if not self._is_current():
+            return
+        self._buffer = ""
+        chunks = self._formatter.format_response(full_response) if full_response else []
+        if not chunks:
+            return
+        # Edit the status/overflow message with the first chunk (markdown formatted)
+        target_id = self._overflow_message_id or self._message_id
+        remaining = chunks
+        if target_id is not None and await self._bot._edit_text(self._chat_id, target_id, chunks[0], markdown=True):
+            remaining = chunks[1:]
+        # Send remaining chunks as new messages
+        for chunk in remaining:
+            if not self._is_current():
+                break
+            await self._bot.send_markdown(self._chat_id, chunk)
 
 
 class TelegramBot:
@@ -620,10 +727,11 @@ class TelegramBot:
                 else "Started processing your request..."
             )
             self._bind_session_memory(message.chat_id, session)
+            streaming = self._config.streaming.streaming_enabled
             handle = await session.agent.submit(
                 message.text,
                 work_dir=self._work_dir,
-                stream=False,
+                stream=streaming,
                 show_progress=False,
             )
             try:
@@ -724,6 +832,19 @@ class TelegramBot:
         )
         status_message_id = message.status_message_id
         self._bind_session_memory(message.chat_id, session)
+        streaming_cfg = self._config.streaming if self._config.streaming.streaming_enabled else None
+        streamer: _StreamingDeliveryManager | None = None
+        if streaming_cfg and handle is not None and status_message_id is not None:
+            streamer = _StreamingDeliveryManager(
+                bot=self,
+                chat_id=message.chat_id,
+                status_message_id=status_message_id,
+                formatter=self._formatter,
+                cfg=streaming_cfg,
+                is_current=lambda: self._is_delivery_current(token, session),
+                stop_markup=self._stop_task_markup(handle.id),
+            )
+            session.agent.add_event_callback(streamer.on_chunk)
         async with self._typing_session(message.chat_id):
             try:
                 if handle is None:
@@ -735,11 +856,16 @@ class TelegramBot:
                         queue_if_busy=False,
                     )
                 else:
-                    response = await handle.wait()
+                    if streamer is not None:
+                        response = await self._wait_with_streaming(handle, streamer)
+                    else:
+                        response = await handle.wait()
             except asyncio.CancelledError:
                 current = asyncio.current_task()
                 if current is not None and current.cancelling():
                     raise
+                if streamer is not None:
+                    session.agent.remove_event_callback(streamer.on_chunk)
                 await self._deliver_status_or_text_if_current(
                     token,
                     session,
@@ -748,6 +874,8 @@ class TelegramBot:
                 )
                 return
             except BusyError:
+                if streamer is not None:
+                    session.agent.remove_event_callback(streamer.on_chunk)
                 await self._deliver_status_or_text_if_current(
                     token,
                     session,
@@ -756,6 +884,8 @@ class TelegramBot:
                 )
                 return
             except Exception as exc:
+                if streamer is not None:
+                    session.agent.remove_event_callback(streamer.on_chunk)
                 logger.exception("Failed to process Telegram message.")
                 await self._deliver_status_or_markdown_if_current(
                     token,
@@ -765,14 +895,36 @@ class TelegramBot:
                 )
                 return
 
+            if streamer is not None:
+                session.agent.remove_event_callback(streamer.on_chunk)
+
             response_text = response or ""
             if not self._is_delivery_current(token, session):
                 return
             if response_text:
-                chunks = self._formatter.format_response(response_text)
-                await self._deliver_response_chunks(token, session, status_message_id, chunks)
+                if streamer is not None:
+                    await streamer.finalize(response_text)
+                else:
+                    chunks = self._formatter.format_response(response_text)
+                    await self._deliver_response_chunks(token, session, status_message_id, chunks)
             elif status_message_id is not None:
                 await self._edit_if_current(token, session, status_message_id, "Done.")
+
+    async def _wait_with_streaming(self, handle: Any, streamer: _StreamingDeliveryManager) -> str:
+        """Wait for a turn while periodically flushing streaming chunks to Telegram."""
+        flush_interval = max(0.3, self._config.streaming.streaming_interval_seconds)
+        while not handle.done:
+            try:
+                await asyncio.wait_for(asyncio.shield(handle.wait()), timeout=flush_interval)
+                break
+            except TimeoutError:
+                await streamer.maybe_flush()
+            except TurnCancelledError:
+                raise
+            except asyncio.CancelledError:
+                raise
+        await streamer.maybe_flush()
+        return await handle.wait()
 
     def _is_delivery_current(self, token: TelegramDeliveryToken, session: Any) -> bool:
         if session.session_id != token.session_id or getattr(session, "generation", 0) != token.generation:

--- a/src/amcp/telegram/config.py
+++ b/src/amcp/telegram/config.py
@@ -24,6 +24,14 @@ class TelegramPairingConfig:
 
 
 @dataclass
+class TelegramStreamingConfig:
+    streaming_enabled: bool = True
+    streaming_interval_seconds: float = 1.5
+    streaming_min_chars: int = 50
+    streaming_max_chars: int = 3900
+
+
+@dataclass
 class TelegramTopicConfig:
     enabled: bool = True
     group_policy: str | None = None
@@ -58,6 +66,7 @@ class TelegramConfig:
     typing_interval_seconds: int = 4
     max_queue_size: int = 20
     pairing: TelegramPairingConfig = field(default_factory=TelegramPairingConfig)
+    streaming: TelegramStreamingConfig = field(default_factory=TelegramStreamingConfig)
     groups: dict[str, TelegramGroupConfig] = field(default_factory=dict)
     notifications: TelegramNotificationsConfig = field(default_factory=TelegramNotificationsConfig)
     assistant_mode: bool = False

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -9,7 +9,13 @@ import pytest
 
 from amcp.runtime import CancellationResult
 from amcp.telegram.auth import AuthMiddleware
-from amcp.telegram.config import TelegramConfig, TelegramGroupConfig, TelegramPairingConfig, TelegramTopicConfig
+from amcp.telegram.config import (
+    TelegramConfig,
+    TelegramGroupConfig,
+    TelegramPairingConfig,
+    TelegramStreamingConfig,
+    TelegramTopicConfig,
+)
 from amcp.telegram.formatter import TelegramFormatter
 from amcp.telegram.handlers import (
     RateLimiter,
@@ -1359,3 +1365,188 @@ def test_process_message_suppresses_result_chunks_after_abandon():
         edit_text.assert_not_awaited()
 
     asyncio.run(_run())
+
+
+def test_streaming_config_defaults():
+    cfg = TelegramStreamingConfig()
+    assert cfg.streaming_enabled is True
+    assert cfg.streaming_interval_seconds == 1.5
+    assert cfg.streaming_min_chars == 50
+    assert cfg.streaming_max_chars == 3900
+
+
+def test_streaming_config_disabled():
+    cfg = TelegramStreamingConfig(streaming_enabled=False)
+    assert cfg.streaming_enabled is False
+
+
+def test_streaming_config_validation():
+    cfg = TelegramStreamingConfig(streaming_interval_seconds=0.1, streaming_min_chars=1, streaming_max_chars=100)
+    assert cfg.streaming_interval_seconds == 0.1
+    assert cfg.streaming_min_chars == 1
+    assert cfg.streaming_max_chars == 100
+
+
+def test_telegram_config_has_streaming_field():
+    cfg = TelegramConfig()
+    assert hasattr(cfg, "streaming")
+    assert isinstance(cfg.streaming, TelegramStreamingConfig)
+    assert cfg.streaming.streaming_enabled is True
+
+
+def test_streaming_delivery_manager_accumulates_chunks():
+    """Test that _StreamingDeliveryManager accumulates chunks from the event callback."""
+    from amcp.telegram.bot import _StreamingDeliveryManager
+
+    formatter = TelegramFormatter(max_length=4096)
+    cfg = TelegramStreamingConfig(streaming_min_chars=1, streaming_interval_seconds=0.0)
+
+    class _FakeBot:
+        def _get_telegram_message_id(self, msg):
+            return 42
+
+        async def _edit_text(self, chat_id, message_id, text, markdown=False):
+            return True
+
+        async def send_text(self, chat_id, text):
+            pass
+
+        async def send_markdown(self, chat_id, text):
+            pass
+
+    bot = _FakeBot()
+    manager = _StreamingDeliveryManager(
+        bot=bot,
+        chat_id=123,
+        status_message_id=1,
+        formatter=formatter,
+        cfg=cfg,
+        is_current=lambda: True,
+    )
+
+    # Simulate chunk events (synchronous, called from agent _emit_event)
+    manager.on_chunk("message.chunk", {"content": "Hello "})
+    manager.on_chunk("message.chunk", {"content": "world!"})
+
+    # The buffer should have accumulated
+    assert manager._buffer == "Hello world!"
+    assert manager._needs_flush is True
+
+
+def test_streaming_delivery_manager_ignores_non_chunk_events():
+    """Test that _StreamingDeliveryManager ignores non-chunk events."""
+    from amcp.telegram.bot import _StreamingDeliveryManager
+
+    formatter = TelegramFormatter(max_length=4096)
+    cfg = TelegramStreamingConfig()
+
+    class _FakeBot:
+        def _get_telegram_message_id(self, msg):
+            return 42
+
+        async def _edit_text(self, chat_id, message_id, text, markdown=False):
+            return True
+
+        async def send_text(self, chat_id, text):
+            pass
+
+        async def send_markdown(self, chat_id, text):
+            pass
+
+    bot = _FakeBot()
+    manager = _StreamingDeliveryManager(
+        bot=bot,
+        chat_id=123,
+        status_message_id=1,
+        formatter=formatter,
+        cfg=cfg,
+        is_current=lambda: True,
+    )
+
+    # Non-chunk events should not affect buffer
+    manager.on_chunk("tool.call_start", {"tool_name": "bash"})
+    manager.on_chunk("tool.call_complete", {"tool_name": "bash"})
+    assert manager._buffer == ""
+    assert manager._needs_flush is False
+
+
+def test_streaming_delivery_manager_flush_edits_message():
+    """Test that maybe_flush edits the status message with accumulated text."""
+    from amcp.telegram.bot import _StreamingDeliveryManager
+
+    formatter = TelegramFormatter(max_length=4096)
+    cfg = TelegramStreamingConfig(streaming_min_chars=1, streaming_interval_seconds=0.0)
+    edits: list[str] = []
+
+    class _FakeBot:
+        def _get_telegram_message_id(self, msg):
+            return 42
+
+        async def _edit_text(self, chat_id, message_id, text, markdown=False):
+            edits.append(text)
+            return True
+
+        async def send_text(self, chat_id, text):
+            pass
+
+        async def send_markdown(self, chat_id, text):
+            pass
+
+    bot = _FakeBot()
+    manager = _StreamingDeliveryManager(
+        bot=bot,
+        chat_id=123,
+        status_message_id=1,
+        formatter=formatter,
+        cfg=cfg,
+        is_current=lambda: True,
+    )
+
+    manager.on_chunk("message.chunk", {"content": "Hello world!"})
+    asyncio.run(manager.maybe_flush())
+    assert len(edits) == 1
+    assert edits[0] == "Hello world!"
+
+
+def test_streaming_delivery_manager_respects_is_current():
+    """Test that _StreamingDeliveryManager stops delivering when session is no longer current."""
+    from amcp.telegram.bot import _StreamingDeliveryManager
+
+    formatter = TelegramFormatter(max_length=4096)
+    cfg = TelegramStreamingConfig(streaming_min_chars=1, streaming_interval_seconds=0.0)
+
+    class _FakeBot:
+        def _get_telegram_message_id(self, msg):
+            return 42
+
+        async def _edit_text(self, chat_id, message_id, text, markdown=False):
+            return True
+
+        async def send_text(self, chat_id, text):
+            pass
+
+        async def send_markdown(self, chat_id, text):
+            pass
+
+    is_current = [True]
+    bot = _FakeBot()
+    manager = _StreamingDeliveryManager(
+        bot=bot,
+        chat_id=123,
+        status_message_id=1,
+        formatter=formatter,
+        cfg=cfg,
+        is_current=lambda: is_current[0],
+    )
+
+    # When current, chunks accumulate
+    manager.on_chunk("message.chunk", {"content": "Hello"})
+    assert manager._buffer == "Hello"
+
+    # When not current, maybe_flush should do nothing
+    is_current[0] = False
+    asyncio.run(manager.maybe_flush())
+    # Buffer still has content but no edit was made (would need to check bot._edit_text calls)
+
+    # finalize should also do nothing when not current
+    asyncio.run(manager.finalize("Hello world!"))

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1031,6 +1031,12 @@ def test_handle_prompt_starts_background_worker_and_returns():
             def queued_count(self) -> int:
                 return 0
 
+            def add_event_callback(self, callback) -> None:
+                pass
+
+            def remove_event_callback(self, callback) -> None:
+                pass
+
             async def submit(self, prompt, **kwargs):
                 self._busy = True
                 handle = MagicMock(id="turn-slow")
@@ -1130,6 +1136,12 @@ def test_handle_prompt_queues_follow_up_for_same_session():
 
             def queued_count(self) -> int:
                 return self._queued
+
+            def add_event_callback(self, callback) -> None:
+                pass
+
+            def remove_event_callback(self, callback) -> None:
+                pass
 
             async def submit(self, prompt, **kwargs):
                 calls.append(prompt)


### PR DESCRIPTION
## Summary

Streams LLM response chunks to Telegram by editing the status message in real-time, giving users live visibility into the agent's output instead of waiting for the full response.

### How it works

1. When streaming is enabled, `_enqueue_message` submits the turn with `stream=True`
2. The agent emits `message.chunk` events via its event callback system
3. `_StreamingDeliveryManager` accumulates chunks and throttles `edit_message_text` calls (default 1.5s interval)
4. `_wait_with_streaming` polls the turn handle, flushing accumulated text between intervals
5. On completion, `finalize()` delivers the full markdown-formatted response

### Stop task button

The Stop task button remains fully functional during streaming. Cancellation happens at the runtime level (`handle.cancel()` → `asyncio.CancelledError`), independent of the delivery mechanism. The button callback calls `cancel_turn()` which interrupts the LLM call and raises `TurnCancelledError`.

### Configuration

```toml
[telegram.streaming]
streaming_enabled = true           # default: true
streaming_interval_seconds = 1.5   # edit throttle (min 0.3s)
streaming_min_chars = 50           # minimum accumulated chars before first edit
streaming_max_chars = 3900         # seal message and start new when exceeded
```

### Changes

| File | Change |
|------|--------|
| `telegram/config.py` | Add `TelegramStreamingConfig` dataclass |
| `config.py` | Add decode/import for streaming config |
| `telegram/bot.py` | Add `_StreamingDeliveryManager`, modify `_enqueue_message` and `_process_message`, add `_wait_with_streaming` |
| `tests/test_telegram.py` | 7 new tests for streaming config and delivery manager |

### Testing

- 7 new streaming tests: all pass
- 15 config tests: all pass
- ruff check + format: clean
- Existing tests: no new failures (25 pre-existing Telegram test failures due to missing python-telegram-bot in CI env, same as main)