### PR TITLE
chore: unify default server port from 4096 to 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@
 #   docker build -t amcp .
 #
 # Run:
-#   docker run -p 4096:4096 amcp
-#   docker run -p 4096:4096 -v /path/to/project:/workspace amcp \
+#   docker run -p 8080:8080 amcp
+#   docker run -p 8080:8080 -v /path/to/project:/workspace amcp \
 #       serve --host 0.0.0.0 --work-dir /workspace
 #
 # With scheduler & reactor:
-#   docker run -p 4096:4096 -v ./config.toml:/root/.config/amcp/config.toml \
+#   docker run -p 8080:8080 -v ./config.toml:/root/.config/amcp/config.toml \
 #       amcp serve --host 0.0.0.0 --scheduler --reactor
 
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
@@ -46,9 +46,9 @@ WORKDIR /workspace
 
 # Health check — hits the server /api/v1/health endpoint
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:4096/api/v1/health')" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/v1/health')" || exit 1
 
-EXPOSE 4096
+EXPOSE 8080
 
 ENTRYPOINT ["/usr/bin/tini", "--", "amcp"]
 CMD ["serve", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ amcp mcp tools --server custom
 amcp mcp call --server custom --tool example_tool --args '{"query":"rust async"}'
 
 # HTTP/WebSocket server
-amcp serve                              # start on localhost:4096
+amcp serve                              # start on localhost:8080
 amcp serve --port 8080 --host 0.0.0.0   # requires [server.auth] configuration
 amcp serve --telegram                   # start Telegram bot alongside
-amcp attach http://localhost:4096       # connect to a running server
+amcp attach http://localhost:8080       # connect to a running server
 amcp attach https://server.example --api-key "$AMCP_SERVER_API_KEY"
 
 # Telegram bot
@@ -200,10 +200,10 @@ See [docs/skills-and-commands.md](docs/skills-and-commands.md) for details and [
 AMCP can run as an HTTP/WebSocket server for remote access:
 
 ```bash
-amcp serve                    # start on localhost:4096
+amcp serve                    # start on localhost:8080
 amcp serve --port 8080        # custom port
 amcp serve -w /path/to/project  # set working directory
-amcp attach http://localhost:4096  # connect from another terminal
+amcp attach http://localhost:8080  # connect from another terminal
 ```
 
 **API endpoints** (visit `/docs` for interactive Swagger UI):
@@ -380,7 +380,7 @@ response_ratio = 0.30          # reserve 30% of context for response
 ```toml
 [server]
 host = "127.0.0.1"
-port = 4096
+port = 8080
 
 [server.auth]
 enabled = false              # valid without a key only for loopback binds

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   amcp:
     build: ..
     ports:
-      - "4096:4096"
+      - "8080:8080"
     volumes:
       - ./config.toml:/root/.config/amcp/config.toml:ro
       - amcp-data:/root/.config/amcp

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,7 +1,7 @@
 # AMCP API Reference
 
 > **Version**: 1.0.0
-> **Base URL**: `http://localhost:4096/api/v1`
+> **Base URL**: `http://localhost:8080/api/v1`
 > **OpenAPI Spec**: `/openapi.json`
 
 This document provides comprehensive API documentation for the AMCP Server HTTP REST API, WebSocket API, and SSE event streams.
@@ -365,7 +365,7 @@ Same event format as global events, but filtered to the specific session.
 ### Connection
 
 ```
-ws://localhost:4096/ws?session_id={session_id}
+ws://localhost:8080/ws?session_id={session_id}
 ```
 
 ### Message Format
@@ -571,7 +571,7 @@ All errors follow this format:
 ```python
 from amcp.client import AMCPClient
 
-async with AMCPClient("http://localhost:4096") as client:
+async with AMCPClient("http://localhost:8080") as client:
     # Create session
     session = await client.create_session(cwd="/my/project")
 
@@ -588,7 +588,7 @@ async with AMCPClient("http://localhost:4096") as client:
 ```typescript
 import type { paths, Session } from './types/amcp-api';
 
-const response = await fetch('http://localhost:4096/api/v1/sessions', {
+const response = await fetch('http://localhost:8080/api/v1/sessions', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({ cwd: '/my/project' })
@@ -600,7 +600,7 @@ const session: Session = await response.json();
 ### WebSocket (JavaScript)
 
 ```javascript
-const ws = new WebSocket('ws://localhost:4096/ws?session_id=my-session');
+const ws = new WebSocket('ws://localhost:8080/ws?session_id=my-session');
 
 ws.onmessage = (event) => {
   const msg = JSON.parse(event.data);

--- a/docs/api/protocol-compatibility.md
+++ b/docs/api/protocol-compatibility.md
@@ -209,7 +209,7 @@ Generate TypeScript types for web clients:
 
 ```bash
 # From running server
-python scripts/generate_types.py --server http://localhost:4096
+python scripts/generate_types.py --server http://localhost:8080
 
 # Manual generation
 python scripts/generate_types.py --manual

--- a/docs/architecture/client-server.md
+++ b/docs/architecture/client-server.md
@@ -82,7 +82,7 @@ This document describes the Client-Server (C/S) architecture for AMCP, enabling 
 http://{host}:{port}/api/v1
 ```
 
-Default: `http://localhost:4096/api/v1`
+Default: `http://localhost:8080/api/v1`
 
 ### Authentication
 
@@ -407,7 +407,7 @@ class EventType(str, Enum):
    from amcp.client import AMCPClient
    
    # For Python applications (async)
-   async with AMCPClient("http://localhost:4096") as client:
+   async with AMCPClient("http://localhost:8080") as client:
        # Create session
        session = await client.create_session(cwd="/my/project")
        
@@ -423,7 +423,7 @@ class EventType(str, Enum):
    ```python
    from amcp.client import WebSocketClient
    
-   async with WebSocketClient("http://localhost:4096", session_id="my-session") as ws:
+   async with WebSocketClient("http://localhost:8080", session_id="my-session") as ws:
        await ws.send_prompt("Hello")
        async for chunk in ws.prompt_stream("What can you do?"):
            if chunk.done:
@@ -513,7 +513,7 @@ class EventType(str, Enum):
 5. ✅ TypeScript type generation
    - Created `scripts/generate_types.py`
    - Supports both npx-based and manual generation
-   - Usage: `python scripts/generate_types.py --server http://localhost:4096`
+   - Usage: `python scripts/generate_types.py --server http://localhost:8080`
 
 6. ✅ Comprehensive API documentation
    - `docs/api/README.md` - Full API reference with examples
@@ -628,14 +628,14 @@ src/amcp/
 
 ```bash
 # Start server in headless mode
-amcp serve [--port 4096] [--host 0.0.0.0]
+amcp serve [--port 8080] [--host 0.0.0.0]
 
 # Connect to running server
 amcp attach <url> [--session <id>]
 
 # Example usage
-amcp serve --port 4096
-amcp attach http://localhost:4096 --session my-session
+amcp serve --port 8080
+amcp attach http://localhost:8080 --session my-session
 ```
 
 ### Modified Commands
@@ -657,7 +657,7 @@ amcp --mode remote --server http://... "help me"  # Force remote
 # ~/.config/amcp/server.yaml
 server:
   host: "0.0.0.0"
-  port: 4096
+  port: 8080
   cors_origins:
     - "http://localhost:*"
     - "tauri://localhost"
@@ -671,7 +671,7 @@ server:
 ```yaml
 # ~/.config/amcp/config.yaml
 client:
-  default_server: "http://localhost:4096"
+  default_server: "http://localhost:8080"
   timeout: 30
   retry_attempts: 3
 ```

--- a/scripts/generate_types.py
+++ b/scripts/generate_types.py
@@ -245,8 +245,8 @@ def main() -> int:
     parser.add_argument(
         "--server",
         "-s",
-        default="http://localhost:4096",
-        help="AMCP server URL (default: http://localhost:4096)",
+        default="http://localhost:8080",
+        help="AMCP server URL (default: http://localhost:8080)",
     )
     parser.add_argument(
         "--output",

--- a/src/amcp/cli.py
+++ b/src/amcp/cli.py
@@ -243,7 +243,7 @@ def serve_command(
     port: Annotated[
         int,
         typer.Option("--port", "-p", help="Port to listen on"),
-    ] = 4096,
+    ] = 8080,
     work_dir: Annotated[
         Path | None,
         typer.Option(
@@ -271,16 +271,16 @@ def serve_command(
     AMCP does not start in-process daemon background orchestration.
 
     Examples:
-        amcp serve                          # Start on localhost:4096
+        amcp serve                          # Start on localhost:8080
         amcp serve --port 8080             # Use custom port
         amcp serve --host 0.0.0.0          # Listen on all interfaces
         amcp serve -w /path/to/project     # Set default working directory
 
     API Documentation:
-        Once running, visit http://localhost:4096/docs for API docs.
+        Once running, visit http://localhost:8080/docs for API docs.
 
     Connect with:
-        amcp attach http://localhost:4096   # Connect CLI to running server
+        amcp attach http://localhost:8080   # Connect CLI to running server
 
     Deploy with Docker or systemd for production.
     """
@@ -359,7 +359,7 @@ def _start_telegram_bot(work_dir: Path | None) -> None:
 def attach_command(
     url: Annotated[
         str,
-        typer.Argument(help="URL of the AMCP server (e.g., http://localhost:4096)"),
+        typer.Argument(help="URL of the AMCP server (e.g., http://localhost:8080)"),
     ],
     session_id: Annotated[
         str | None,
@@ -392,9 +392,9 @@ def attach_command(
     or in another process.
 
     Examples:
-        amcp attach http://localhost:4096
-        amcp attach http://remote-server:4096 --session my-session
-        amcp attach http://localhost:4096 -w /path/to/project
+        amcp attach http://localhost:8080
+        amcp attach http://remote-server:8080 --session my-session
+        amcp attach http://localhost:8080 -w /path/to/project
     """
     # Use synchronous implementation to avoid event loop issues
     _attach_sync(url, session_id, work_dir, api_key)

--- a/src/amcp/client/__init__.py
+++ b/src/amcp/client/__init__.py
@@ -5,7 +5,7 @@ or running agents in embedded mode locally.
 
 Example usage:
     # Remote mode - connect to a server
-    async with AMCPClient("http://localhost:4096") as client:
+    async with AMCPClient("http://localhost:8080") as client:
         session = await client.create_session(cwd="/my/project")
         async for chunk in session.prompt("Help me refactor this"):
             print(chunk.content, end="")
@@ -62,7 +62,7 @@ class AMCPClient:
 
     Examples:
         # Connect to remote server
-        async with AMCPClient("http://localhost:4096") as client:
+        async with AMCPClient("http://localhost:8080") as client:
             session = await client.create_session()
             async for chunk in session.prompt("Hello"):
                 print(chunk)

--- a/src/amcp/client/http_client.py
+++ b/src/amcp/client/http_client.py
@@ -27,7 +27,7 @@ class HTTPClient(BaseClient):
     Uses httpx for async HTTP requests with streaming support.
 
     Example:
-        async with HTTPClient("http://localhost:4096") as client:
+        async with HTTPClient("http://localhost:8080") as client:
             session = await client.create_session()
             async for chunk in await client.prompt(session["id"], "Hello"):
                 print(chunk.content)

--- a/src/amcp/client/ws_client.py
+++ b/src/amcp/client/ws_client.py
@@ -27,7 +27,7 @@ class WebSocketClient:
     Provides bidirectional streaming with the server.
 
     Example:
-        async with WebSocketClient("http://localhost:4096", session_id="my-session") as ws:
+        async with WebSocketClient("http://localhost:8080", session_id="my-session") as ws:
             await ws.send_prompt("Hello")
             async for message in ws:
                 if message.done:

--- a/src/amcp/config.py
+++ b/src/amcp/config.py
@@ -163,7 +163,7 @@ class ServerConfig:
     """Configuration for AMCP Server."""
 
     host: str = "127.0.0.1"
-    port: int = 4096
+    port: int = 8080
     auth: AuthConfig = field(default_factory=AuthConfig)
     cors: CORSConfig = field(default_factory=CORSConfig)
     session_timeout_minutes: int = 60 * 24
@@ -210,7 +210,7 @@ _DEFAULT = {
     "servers": {},
     "server": {
         "host": "127.0.0.1",
-        "port": 4096,
+        "port": 8080,
         "auth": {
             "enabled": False,
         },
@@ -531,7 +531,7 @@ def _decode_server_config(raw: Mapping[str, object] | None) -> ServerConfig | No
     cors_raw = raw.get("cors")
     return ServerConfig(
         host=str(raw.get("host", "127.0.0.1")),
-        port=int(str(raw.get("port", 4096))),
+        port=int(str(raw.get("port", 8080))),
         auth=_decode_auth(auth_raw if isinstance(auth_raw, dict) else None),
         cors=_decode_cors(cors_raw if isinstance(cors_raw, dict) else None, raw.get("cors_origins")),
         session_timeout_minutes=int(str(raw.get("session_timeout_minutes", 1440))),

--- a/src/amcp/server/__init__.py
+++ b/src/amcp/server/__init__.py
@@ -8,10 +8,10 @@ This module provides a FastAPI-based server that allows:
 
 Example usage:
     # Start server
-    amcp serve --port 4096
+    amcp serve --port 8080
 
     # Connect from another terminal
-    amcp attach http://localhost:4096
+    amcp attach http://localhost:8080
 """
 
 from .app import create_app, get_app, run_server

--- a/src/amcp/server/app.py
+++ b/src/amcp/server/app.py
@@ -201,7 +201,7 @@ def get_app() -> FastAPI:
 
 def run_server(
     host: str = "127.0.0.1",
-    port: int = 4096,
+    port: int = 8080,
     work_dir: str | None = None,
     reload: bool = False,
     auth: AuthConfig | None = None,

--- a/src/amcp/server/config.py
+++ b/src/amcp/server/config.py
@@ -49,7 +49,7 @@ class ServerConfig(BaseModel):
     """AMCP Server configuration."""
 
     host: str = "127.0.0.1"
-    port: int = 4096
+    port: int = 8080
     cors: CORSConfig = Field(default_factory=CORSConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -110,9 +110,9 @@ class TestAMCPClient:
 
     def test_remote_mode_creation(self):
         """Test creating client in remote mode."""
-        client = AMCPClient.remote("http://localhost:4096")
+        client = AMCPClient.remote("http://localhost:8080")
         assert client.mode == ClientMode.REMOTE
-        assert client.url == "http://localhost:4096"
+        assert client.url == "http://localhost:8080"
         assert client.is_connected is False
 
     def test_embedded_mode_creation(self):
@@ -123,7 +123,7 @@ class TestAMCPClient:
 
     def test_auto_mode_with_url(self):
         """Test auto mode with URL defaults to remote."""
-        client = AMCPClient.auto("http://localhost:4096")
+        client = AMCPClient.auto("http://localhost:8080")
         assert client.mode == ClientMode.REMOTE
 
     def test_auto_mode_without_url(self):
@@ -133,7 +133,7 @@ class TestAMCPClient:
 
     def test_url_based_mode_detection(self):
         """Test that URL presence determines mode."""
-        with_url = AMCPClient("http://localhost:4096")
+        with_url = AMCPClient("http://localhost:8080")
         assert with_url.mode == ClientMode.REMOTE
 
         without_url = AMCPClient()
@@ -150,25 +150,25 @@ class TestHTTPClient:
 
     def test_client_creation(self):
         """Test client creation."""
-        client = HTTPClient("http://localhost:4096")
-        assert client._url == "http://localhost:4096"
-        assert client.base_url == "http://localhost:4096/api/v1"
+        client = HTTPClient("http://localhost:8080")
+        assert client._url == "http://localhost:8080"
+        assert client.base_url == "http://localhost:8080/api/v1"
         assert client.is_connected is False
 
     def test_url_trailing_slash(self):
         """Test URL normalization."""
-        client = HTTPClient("http://localhost:4096/")
-        assert client._url == "http://localhost:4096"
+        client = HTTPClient("http://localhost:8080/")
+        assert client._url == "http://localhost:8080"
 
     def test_ensure_connected_raises(self):
         """Test that ensure_connected raises when not connected."""
-        client = HTTPClient("http://localhost:4096")
+        client = HTTPClient("http://localhost:8080")
         with pytest.raises(ConnectionError):
             client._ensure_connected()
 
     def test_api_key_adds_bearer_header_without_overriding_headers(self):
         client = HTTPClient(
-            "http://localhost:4096",
+            "http://localhost:8080",
             headers={"X-Custom": "value"},
             api_key="secret",
         )
@@ -178,7 +178,7 @@ class TestHTTPClient:
         }
 
         custom = HTTPClient(
-            "http://localhost:4096",
+            "http://localhost:8080",
             headers={"authorization": "Custom credential"},
             api_key="secret",
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -27,7 +27,7 @@ def server_config():
     """Create a test server configuration."""
     return ServerConfig(
         host="127.0.0.1",
-        port=4096,
+        port=8080,
         max_sessions=5,
     )
 


### PR DESCRIPTION
## Summary

The codebase default server port was `4096` everywhere while the production deployment and the GMI AgentBox image both run on `8080`. This created confusion and a broken health check if the standard `Dockerfile` was used with an `8080` config.

This PR unifies **all** server-related port references to `8080`.

## Changes

| File | Change |
|---|---|
| `src/amcp/config.py` | Default `port` 4096 → 8080 |
| `src/amcp/cli.py` | `--port` default + all examples 4096 → 8080 |
| `src/amcp/server/config.py`, `app.py`, `__init__.py` | Port default 4096 → 8080 |
| `src/amcp/client/__init__.py`, `http_client.py`, `ws_client.py` | Example URLs 4096 → 8080 |
| `scripts/generate_types.py` | Default server URL 4096 → 8080 |
| `Dockerfile` (root) | `EXPOSE`, HEALTHCHECK, run examples 4096 → 8080 |
| `deploy/docker-compose.yml` | Port mapping `4096:4096` → `8080:8080` |
| `README.md`, `docs/api/`, `docs/architecture/` | All examples 4096 → 8080 |
| `tests/test_client.py`, `tests/test_server.py` | Test URLs 4096 → 8080 |

## Not changed (intentional)
- `deploy-gmi/\*` — already used 8080
- `src/amcp/telegram/config.py`, `formatter.py` — `4096` is the Telegram message length limit, not a port
- `docs/phase7-telegram-integration.md` — Telegram message limit
- `tests/test_telegram.py`, `tests/test_models_db.py` — Telegram limit / model output limit

## Test plan
- [x] `pytest tests/test_config.py tests/test_client.py tests/test_server.py` — 118 passed
- [x] `pytest tests/test_telegram.py` — 64 passed
- [x] `ruff check` — all pass